### PR TITLE
Simplify Schedule method

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -7,11 +7,7 @@ addon.timers = addon.timers or {}
 
 function addon:Schedule(name, delay, func, ...)
     self:Cancel(name)
-    if type(func) == "string" then
-        self.timers[name] = self:ScheduleTimer(func, delay, ...)
-    else
-        self.timers[name] = self:ScheduleTimer(func, delay, ...)
-    end
+    self.timers[name] = self:ScheduleTimer(func, delay, ...)
     return self.timers[name]
 end
 


### PR DESCRIPTION
## Summary
- remove redundant conditional in Schedule method

## Testing
- `luacheck '!KRT/KRT.lua'`

------
https://chatgpt.com/codex/tasks/task_e_684a805abb58832e938842b95086d443