### PR TITLE
Expose roll types and colors via addon

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -101,6 +101,11 @@ local classColors = {
 -- Raid Target Icons:
 local markers = {"{circle}", "{diamond}", "{triangle}", "{moon}", "{square}", "{cross}", "{skull}"}
 
+-- Make these tables accessible to other modules
+addon.rollTypes = rollTypes
+addon.itemColors = itemColors
+addon.markers = markers
+
 -- Windows Title String:
 local titleString = "|cfff58cbaK|r|caaf49141RT|r : %s"
 

--- a/!KRT/modules/LootHelpers.lua
+++ b/!KRT/modules/LootHelpers.lua
@@ -72,7 +72,7 @@ do
 
 		lootTable[lootCount]             = {}
 		lootTable[lootCount].itemName    = itemName
-		lootTable[lootCount].itemColor   = itemColors[itemRarity+1]
+                lootTable[lootCount].itemColor   = addon.itemColors[itemRarity+1]
 		lootTable[lootCount].itemLink    = itemLink
 		lootTable[lootCount].itemTexture = itemTexture
 		TriggerEvent("AddItem", itemLink)

--- a/!KRT/modules/LootHistory.lua
+++ b/!KRT/modules/LootHistory.lua
@@ -1139,7 +1139,7 @@ do
 			btn:SetID(v.id)
 			btn:Show()
 
-			_G[btnName.."Name"]:SetText("|c"..itemColors[v.itemRarity+1]..v.itemName.."|r")
+                        _G[btnName.."Name"]:SetText("|c"..addon.itemColors[v.itemRarity+1]..v.itemName.."|r")
 			_G[btnName.."Source"]:SetText(addon.Logger.Boss:GetName(v.bossNum, selectedRaid))
 			local player = v.looter
 			local class = addon:GetPlayerClass(player)

--- a/!KRT/modules/MasterLoot.lua
+++ b/!KRT/modules/MasterLoot.lua
@@ -118,7 +118,7 @@ do
 			local itemID = tonumber(string.match(itemLink or "", "item:(%d+)"))
 			local message = ""
 
-			if rollType == rollTypes.reserved and addon.Reserves and addon.Reserves.FormatReservedPlayersLine then
+			if rollType == addon.rollTypes.reserved and addon.Reserves and addon.Reserves.FormatReservedPlayersLine then
 				local srList = addon.Reserves:FormatReservedPlayersLine(itemID)
 				local suff = addon.options.sortAscending and "Low" or "High"
 				message = itemCount > 1
@@ -192,12 +192,12 @@ do
 		countdownRun = false
 		local itemLink = GetItemLink()
 		if itemLink == nil then return end
-		currentRollType = rollTypes.hold
+		currentRollType = addon.rollTypes.hold
 		addon:Debug("DEBUG", "Holding item %s for %s", itemLink, holder)
 		if fromInventory == true then
-			return TradeItem(itemLink, holder, rollTypes.hold, 0)
+			return TradeItem(itemLink, holder, addon.rollTypes.hold, 0)
 		end
-		return AssignItem(itemLink, holder, rollTypes.hold, 0)
+		return AssignItem(itemLink, holder, addon.rollTypes.hold, 0)
 	end
 
 	-- Button: Bank item
@@ -207,12 +207,12 @@ do
 		countdownRun = false
 		local itemLink = GetItemLink()
 		if itemLink == nil then return end
-		currentRollType = rollTypes.bank
+		currentRollType = addon.rollTypes.bank
 		addon:Debug("DEBUG", "Banking item %s to %s", itemLink, banker)
 		if fromInventory == true then
-			return TradeItem(itemLink, banker, rollTypes.bank, 0)
+			return TradeItem(itemLink, banker, addon.rollTypes.bank, 0)
 		end
-		return AssignItem(itemLink, banker, rollTypes.bank, 0)
+		return AssignItem(itemLink, banker, addon.rollTypes.bank, 0)
 	end
 
 	-- Button: Disenchant item
@@ -222,12 +222,12 @@ do
 		countdownRun = false
 		local itemLink = GetItemLink()
 		if itemLink == nil then return end
-		currentRollType = rollTypes.disenchant
+		currentRollType = addon.rollTypes.disenchant
 		addon:Debug("DEBUG", "Disenchanting item %s by %s", itemLink, disenchanter)
 		if fromInventory == true then
-			return TradeItem(itemLink, disenchanter, rollTypes.disenchant, 0)
+			return TradeItem(itemLink, disenchanter, addon.rollTypes.disenchant, 0)
 		end
-		return AssignItem(itemLink, disenchanter, rollTypes.disenchant, 0)
+		return AssignItem(itemLink, disenchanter, addon.rollTypes.disenchant, 0)
 	end
 
 	-- Select winner:
@@ -648,17 +648,17 @@ do
 				local output, whisper
 				if rollType <= 4 and addon.options.announceOnWin then
 					output = L.ChatAward:format(playerName, itemLink)
-				elseif rollType == rollTypes.hold and addon.options.announceOnHold then
+				elseif rollType == addon.rollTypes.hold and addon.options.announceOnHold then
 					output = L.ChatHold:format(playerName, itemLink)
 					if addon.options.lootWhispers then
 						whisper = L.WhisperHoldAssign:format(itemLink)
 					end
-				elseif rollType == rollTypes.bank and addon.options.announceOnBank then
+				elseif rollType == addon.rollTypes.bank and addon.options.announceOnBank then
 					output = L.ChatBank:format(playerName, itemLink)
 					if addon.options.lootWhispers then
 						whisper = L.WhisperBankAssign:format(itemLink)
 					end
-				elseif rollType == rollTypes.disenchant and addon.options.announceOnDisenchant then
+				elseif rollType == addon.rollTypes.disenchant and addon.options.announceOnDisenchant then
 					output = L.ChatDisenchant:format(itemLink, playerName)
 					if addon.options.lootWhispers then
 						whisper = L.WhisperDisenchantAssign:format(itemLink)
@@ -692,21 +692,21 @@ do
 		if rollType <= 4 and addon.options.announceOnWin then
 			output = L.ChatAward:format(playerName, itemLink)
 			keep = false
-		elseif rollType == rollTypes.hold and addon.options.announceOnHold then
+		elseif rollType == addon.rollTypes.hold and addon.options.announceOnHold then
 			output = L.ChatNoneRolledHold:format(itemLink, playerName)
-		elseif rollType == rollTypes.bank and addon.options.announceOnBank then
+		elseif rollType == addon.rollTypes.bank and addon.options.announceOnBank then
 			output = L.ChatNoneRolledBank:format(itemLink, playerName)
-		elseif rollType == rollTypes.disenchant and addon.options.announceOnDisenchant then
+		elseif rollType == addon.rollTypes.disenchant and addon.options.announceOnDisenchant then
 			output = L.ChatNoneRolledDisenchant:format(itemLink, playerName)
 		end
 
 		-- Keeping the item:
 		if keep then
-			if rollType == rollTypes.hold then
+			if rollType == addon.rollTypes.hold then
 				whisper = L.WhisperHoldTrade:format(itemLink)
-			elseif rollType == rollTypes.bank then
+			elseif rollType == addon.rollTypes.bank then
 				whisper = L.WhisperBankTrade:format(itemLink)
-			elseif rollType == rollTypes.disenchant then
+			elseif rollType == addon.rollTypes.disenchant then
 				whisper = L.WhisperDisenchantTrade:format(itemLink)
 			end
 		-- Multiple winners:
@@ -721,7 +721,7 @@ do
 						tinsert(winners, "{star} "..rolls[i].name.."("..rolls[i].roll..")")
 					else
 						SetRaidTarget(rolls[i].name, i + 1)
-						tinsert(winners, markers[i].." "..rolls[i].name.."("..rolls[i].roll..")")
+                                                tinsert(winners, addon.markers[i].." "..rolls[i].name.."("..rolls[i].roll..")")
 					end
 				end
 			end
@@ -766,7 +766,7 @@ do
 					Utils.whisper(playerName, whisper)
 				end
 			end
-			if rollType <= rollTypes.free and playerName == trader then
+			if rollType <= addon.rollTypes.free and playerName == trader then
 				addon:Log(currentRollItem, trader, rollType, rollValue)
 			end
 			announced = true

--- a/!KRT/modules/RollHelpers.lua
+++ b/!KRT/modules/RollHelpers.lua
@@ -44,7 +44,7 @@ do
 		SortRolls()
 		if not selectedPlayer then
 			local resolvedItemId = itemId or addon:GetCurrentRollItemID()
-			if currentRollType == rollTypes.reserved then
+			if currentRollType == addon.rollTypes.reserved then
 				local topRoll = -1
 				for _, entry in ipairs(rollsTable) do
 					if addon:IsReserved(resolvedItemId, entry.name) and entry.roll > topRoll then
@@ -70,7 +70,7 @@ do
 		local name = UnitName("player")
 		local allowed = 1
 
-		if currentRollType == rollTypes.reserved then
+		if currentRollType == addon.rollTypes.reserved then
 			allowed = addon.Reserves:GetReserveCountForItem(itemId, name)
 		end
 
@@ -120,7 +120,7 @@ do
 			end
 
 			local allowed = 1
-			if currentRollType == rollTypes.reserved then
+			if currentRollType == addon.rollTypes.reserved then
 				local playerReserves = addon.Reserves:GetReserveCountForItem(itemId, player)
 				allowed = playerReserves > 0 and playerReserves or 1
 			end
@@ -168,7 +168,7 @@ do
 		end
 		itemRollTracker[itemId] = itemRollTracker[itemId] or {}
 		local used = itemRollTracker[itemId][name] or 0
-		local allowed = (currentRollType == rollTypes.reserved and addon.Reserves:GetReserveCountForItem(itemId, name) > 0)
+		local allowed = (currentRollType == addon.rollTypes.reserved and addon.Reserves:GetReserveCountForItem(itemId, name) > 0)
 			and addon.Reserves:GetReserveCountForItem(itemId, name) or 1
 		local result = used >= allowed
 		addon:Debug("DEBUG", "DidRoll: name=%s, itemId=%d, used=%d, allowed=%d, result=%s", name, itemId, used, allowed, tostring(result))
@@ -224,7 +224,7 @@ do
 	function addon:IsValidRoll(itemId, name)
 		itemRollTracker[itemId] = itemRollTracker[itemId] or {}
 		local used = itemRollTracker[itemId][name] or 0
-		local allowed = (currentRollType == rollTypes.reserved)
+		local allowed = (currentRollType == addon.rollTypes.reserved)
 			and addon.Reserves:GetReserveCountForItem(itemId, name)
 			or 1
 		local result = used < allowed
@@ -264,7 +264,7 @@ do
 		scrollChild:SetWidth(scrollFrame:GetWidth())
 
 		local itemId = self:GetCurrentRollItemID()
-		local isSR = currentRollType == rollTypes.reserved
+		local isSR = currentRollType == addon.rollTypes.reserved
 		addon:Debug("DEBUG", "Current itemId: %s, SR mode: %s", tostring(itemId), tostring(isSR))
 
 		local starTarget = selectedPlayer


### PR DESCRIPTION
## Summary
- expose common tables in `KRT.lua`
- reference new addon fields in LootHelpers, LootHistory, MasterLoot and RollHelpers

## Testing
- `luacheck !KRT/KRT.lua !KRT/modules/LootHelpers.lua !KRT/modules/LootHistory.lua !KRT/modules/MasterLoot.lua !KRT/modules/RollHelpers.lua`

------
https://chatgpt.com/codex/tasks/task_e_684ae0c34cf8832eae1cd684553b3612