### PR TITLE
Fix string.endsWith implementation

### DIFF
--- a/!KRT/modules/Utils.lua
+++ b/!KRT/modules/Utils.lua
@@ -78,7 +78,8 @@ end
 
 -- String ends with:
 _G.string.endsWith = function(str, piece)
-	return #str >= #piece and find(str, #str - #piece + 1, true) and true or false
+        return #str >= #piece
+                and find(str, piece, #str - #piece + 1, true) ~= nil
 end
 
 -- Uppercase first:


### PR DESCRIPTION
## Summary
- correct logic in `string.endsWith` to properly check suffix

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_684aee6783b8832ea11d9c5cb3db101e