### PR TITLE
Fix loot deletion variable

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -5269,11 +5269,11 @@ do
 				end
 			end
 			-- We delete all the loot from that player:
-			for i = #raid.loot, 1, -1 do
-				if l.bossNum == selectedPlayer then
-					tremove(raid.loot, i)
-				end
-			end
+                        for i = #raid.loot, 1, -1 do
+                                if raid.loot[i].bossNum == selectedPlayer then
+                                        tremove(raid.loot, i)
+                                end
+                        end
 			fetched = false
 		end
 


### PR DESCRIPTION
## Summary
- fix variable reference when removing loot entries

## Testing
- `luacheck '!KRT/KRT.lua'`

------
https://chatgpt.com/codex/tasks/task_e_684bbd29c4ec832e8e7d7f6a811918ac