### PR TITLE
Replace custom callbacks with CallbackHandler

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -86,7 +86,6 @@ local markers = {"{circle}", "{diamond}", "{triangle}", "{moon}", "{square}", "{
 local titleString = "|cfff58cbaK|r|caaf49141RT|r : %s"
 
 -- Some local functions:
-local TriggerEvent
 local LoadOptions
 
 -- Cache frequently used globals:
@@ -120,37 +119,9 @@ end
 
 -- ==================== Callbacks Helpers ==================== --
 
-do
-	-- Table of registered callbacks:
-	local callbacks = {}
-
-	-- Register a new callback:
-	function addon:RegisterCallback(e, func)
-		if not e or type(func) ~= "function" then
-			error(L.StrCbErrUsage)
-		end
-		callbacks[e] = callbacks[e] or {}
-		tinsert(callbacks[e], func)
-		addon:Debug("DEBUG", "Registered callback for event '%s': %s", tostring(e), tostring(func))
-		return #callbacks
-	end
-
-	-- Trigger a registered event:
-	function TriggerEvent(e, ...)
-		if not callbacks[e] then
-			addon:Debug("DEBUG", "No callbacks registered for event '%s'", tostring(e))
-			return
-		end
-		addon:Debug("DEBUG", "Triggering event '%s' (%d callbacks)", tostring(e), #callbacks[e])
-		for i, v in ipairs(callbacks[e]) do
-			local ok, err = pcall(v, e, ...)
-			if not ok then
-				addon:Debug("ERROR", "Error in callback %s for event '%s': %s", tostring(v), tostring(e), tostring(err))
-				addon:PrintError(L.StrCbErrExec:format(tostring(v), tostring(e), err))
-			end
-		end
-	end
-end
+local CallbackHandler = LibStub("CallbackHandler-1.0")
+addon.callbacks = CallbackHandler:New(addon,
+    "RegisterCallback", "UnregisterCallback", "UnregisterAllCallbacks")
 
 -- ==================== Events System ==================== --
 

--- a/!KRT/core/Config.lua
+++ b/!KRT/core/Config.lua
@@ -100,7 +100,7 @@ local Config = addon.Config
 			addon:Debug("DEBUG", "Setting countdown duration to: %d", value)
 		end
 		name = strsub(name, strlen(frameName) + 1)
-		TriggerEvent("Config"..name, value)
+               addon.callbacks:Fire("Config"..name, value)
 		KRT_Options[name] = value
 		addon:Debug("DEBUG", "Option %s set to: %s", name, tostring(value))
 	end

--- a/!KRT/core/Logger.lua
+++ b/!KRT/core/Logger.lua
@@ -73,7 +73,7 @@ local Logger = addon.Logger
 		else
 			addon.Logger.selectedRaid = nil
 		end
-		TriggerEvent("LoggerSelectRaid", rID)
+               addon.callbacks:Fire("LoggerSelectRaid", rID)
 	end
 
 	-- Select a boss:
@@ -85,7 +85,7 @@ local Logger = addon.Logger
 		else
 			addon.Logger.selectedBoss = nil
 		end
-		TriggerEvent("LoggerSelectBoss", bID)
+               addon.callbacks:Fire("LoggerSelectBoss", bID)
 	end
 
 	-- Select a boss attendee:
@@ -97,7 +97,7 @@ local Logger = addon.Logger
 		else
 			addon.Logger.selectedBossPlayer = nil
 		end
-		TriggerEvent("LoggerSelectBossPlayer", pID)
+               addon.callbacks:Fire("LoggerSelectBossPlayer", pID)
 	end
 
 	-- Select a player:
@@ -109,7 +109,7 @@ local Logger = addon.Logger
 		else
 			addon.Logger.selectedPlayer = nil
 		end
-		TriggerEvent("LoggerSelectPlayer", pID)
+               addon.callbacks:Fire("LoggerSelectPlayer", pID)
 	end
 
 	do
@@ -146,7 +146,7 @@ local Logger = addon.Logger
 				else
 					addon.Logger.selectedItem = nil
 				end
-				TriggerEvent("LoggerSelectItem", iID)
+                               addon.callbacks:Fire("LoggerSelectItem", iID)
 			elseif button == "RightButton" then
 				addon.Logger.selectedItem = btn:GetID()
 				OpenItemMenu(btn)
@@ -1412,7 +1412,7 @@ do
 
 		CancelAddEdit()
 		self:Hide()
-		TriggerEvent("LoggerSelectRaid")
+               addon.callbacks:Fire("LoggerSelectRaid")
 	end
 
 	function CancelAddEdit()

--- a/!KRT/core/Loot.lua
+++ b/!KRT/core/Loot.lua
@@ -70,7 +70,7 @@ local Loot = addon.Loot
 		lootTable[lootCount].itemColor   = itemColors[itemRarity+1]
 		lootTable[lootCount].itemLink    = itemLink
 		lootTable[lootCount].itemTexture = itemTexture
-		TriggerEvent("AddItem", itemLink)
+               addon.callbacks:Fire("AddItem", itemLink)
 	end
 
 	-- Prepare item display:
@@ -100,7 +100,7 @@ local Loot = addon.Loot
 				currentItemBtn.tooltip_item = i.itemLink
 				self:SetTooltip(currentItemBtn, nil, "ANCHOR_CURSOR")
 			end
-			TriggerEvent("SetItem", i.itemLink)
+                       addon.callbacks:Fire("SetItem", i.itemLink)
 		end
 
 	end

--- a/!KRT/core/Raid.lua
+++ b/!KRT/core/Raid.lua
@@ -112,7 +112,7 @@ local Raid = addon.Raid
 		tinsert(KRT_Raids, raidInfo)
 		KRT_CurrentRaid = #KRT_Raids
 		addon:Debug("INFO", "Raid created with ID: %d", KRT_CurrentRaid)
-		TriggerEvent("RaidCreate", KRT_CurrentRaid)
+               addon.callbacks:Fire("RaidCreate", KRT_CurrentRaid)
 		Utils.schedule(3, addon.UpdateRaidRoster)
 	end
 

--- a/!KRT/core/Rolls.lua
+++ b/!KRT/core/Rolls.lua
@@ -35,7 +35,7 @@ local Rolls = addon.Rolls
 			addon:Debug("DEBUG", "Updated itemRollTracker: itemId=%d, player=%s, count=%d", itemId, name, itemRollTracker[itemId][name])
 		end
 
-		TriggerEvent("AddRoll", name, roll)
+               addon.callbacks:Fire("AddRoll", name, roll)
 		SortRolls()
 		if not selectedPlayer then
 			local resolvedItemId = itemId or addon:GetCurrentRollItemID()


### PR DESCRIPTION
## Summary
- use CallbackHandler-1.0 in `KRT.lua`
- fire events through `addon.callbacks:Fire`

## Testing
- `luacheck .` *(fails: 330 warnings / 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d388e5180832e9289fab2d6b66a41