### PR TITLE
Add missing libraries to TOC

### DIFF
--- a/!KRT/!KRT.toc
+++ b/!KRT/!KRT.toc
@@ -16,6 +16,9 @@
 
 # Libraries:
 Libs\LibStub.lua
+Libs\CallbackHandler-1.0.lua
+Libs\LibBossIDs-1.0.lua
+Libs\LibCompress.lua
 Libs\LibDeformat-3.0.lua
 
 # Localization (moved to the top for 'L' to be available):


### PR DESCRIPTION
## Summary
- include CallbackHandler, LibBossIDs, and LibCompress libraries in `!KRT.toc`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d3874c638832e8970f76fca05b4b4