### PR TITLE
Replace custom callback with CallbackHandler-1.0

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -280,35 +280,12 @@ end
 -- ==================== Callbacks Helpers ==================== --
 
 do
-	-- Table of registered callbacks:
-	local callbacks = {}
+        addon.callbacks = callbackHandler:New(addon)
 
-	-- Register a new callback:
-	function addon:RegisterCallback(e, func)
-		if not e or type(func) ~= "function" then
-			error(L.StrCbErrUsage)
-		end
-		callbacks[e] = callbacks[e] or {}
-		tinsert(callbacks[e], func)
-		addon:Debug("DEBUG", "Registered callback for event '%s': %s", tostring(e), tostring(func))
-		return #callbacks
-	end
-
-	-- Trigger a registered event:
-	function TriggerEvent(e, ...)
-		if not callbacks[e] then
-			addon:Debug("DEBUG", "No callbacks registered for event '%s'", tostring(e))
-			return
-		end
-		addon:Debug("DEBUG", "Triggering event '%s' (%d callbacks)", tostring(e), #callbacks[e])
-		for i, v in ipairs(callbacks[e]) do
-			local ok, err = pcall(v, e, ...)
-			if not ok then
-				addon:Debug("ERROR", "Error in callback %s for event '%s': %s", tostring(v), tostring(e), tostring(err))
-				addon:PrintError(L.StrCbErrExec:format(tostring(v), tostring(e), err))
-			end
-		end
-	end
+        -- Trigger a registered event using CallbackHandler
+        function TriggerEvent(e, ...)
+                addon.callbacks:Fire(e, ...)
+        end
 end
 
 -- ==================== Events System ==================== --

--- a/!KRT/localization/localization.en.lua
+++ b/!KRT/localization/localization.en.lua
@@ -13,8 +13,6 @@ end})
 local L = addon.L -- Make a local reference for convenience within this file
 
 -- ==================== Callbacks ==================== --
-L.StrCbErrUsage = "Usage: KRT:RegisterCallback(event, callbacks)"
-L.StrCbErrExec = "Error while executing callback %s for event %s: %s"
 
 -- ==================== General Buttons ==================== --
 L.BtnConfig       = "Config"


### PR DESCRIPTION
## Summary
- use CallbackHandler-1.0 for managing callbacks
- clean up unused localization strings

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684d9fe0e508832ebd930531e01f949e