### PR TITLE
Fix GetCurrentTime parameter default

### DIFF
--- a/!KRT/modules/Utils.lua
+++ b/!KRT/modules/Utils.lua
@@ -448,12 +448,14 @@ end
 
 -- Returns the current time:
 function Utils.GetCurrentTime(server)
-	server = server or true
-	local t = time()
-	if server == true then
-		local _, month, day, year = CalendarGetDate()
-		local hour, minute = GetGameTime()
-		t = time({year = year, month = month, day = day, hour = hour, min = minute})
+       if server == nil then
+               server = true
+       end
+       local t = time()
+       if server == true then
+               local _, month, day, year = CalendarGetDate()
+               local hour, minute = GetGameTime()
+               t = time({year = year, month = month, day = day, hour = hour, min = minute})
 	end
 	return t
 end


### PR DESCRIPTION
## Summary
- fix boolean handling in `GetCurrentTime`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684daa1e9040832eb940a1d3e2bd933f