### PR TITLE
Fix GetCurrentTime server flag handling

### DIFF
--- a/!KRT/modules/Utils.lua
+++ b/!KRT/modules/Utils.lua
@@ -448,14 +448,14 @@ end
 
 -- Returns the current time:
 function Utils.GetCurrentTime(server)
-	server = server or true
-	local t = time()
-	if server == true then
-		local _, month, day, year = CalendarGetDate()
-		local hour, minute = GetGameTime()
-		t = time({year = year, month = month, day = day, hour = hour, min = minute})
-	end
-	return t
+        if server == nil then server = true end
+        local t = time()
+        if server == true then
+                local _, month, day, year = CalendarGetDate()
+                local hour, minute = GetGameTime()
+                t = time({year = year, month = month, day = day, hour = hour, min = minute})
+        end
+        return t
 end
 
 -- Returns the server offset:


### PR DESCRIPTION
## Summary
- ensure Utils.GetCurrentTime defaults to server time only when `server` is nil

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dcd4c87f4832e968c22ff15b02310