### PR TITLE
Remove trailing whitespace

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -291,7 +291,7 @@ do
 			-- Switch to party mode if we're in a party:
 			elseif self:IsInParty() then
 				channel = "PARTY"
-				
+
 			-- Switch to alone mode
 			else
 				channel = "SAY"
@@ -600,7 +600,7 @@ end
 function addon:RAID_INSTANCE_WELCOME(...)
 	local instanceName, instanceType, instanceDiff = GetInstanceInfo()
 	_, KRT_NextReset = ...
-	
+
 	if L.RaidZones[instanceName] ~= nil then
 		if KRT then
 			addon:Debug("INFO", "Raid '%s' started. Type: %s, Difficulty: %d", instanceName, instanceType, instanceDiff)

--- a/!KRT/KRT.xml
+++ b/!KRT/KRT.xml
@@ -218,7 +218,7 @@
             </CheckButton>
             <CheckButton name="$parentcountdownSimpleRaidMsg" inherits="KRTConfigCheckButtonTemplate">
                 <Anchors>
-                    <Anchor point="TOPRIGHT" relativeTo="$parentcountdownSimpleRaidMsgStr" relativePoint="TOPLEFT"> 
+                    <Anchor point="TOPRIGHT" relativeTo="$parentcountdownSimpleRaidMsgStr" relativePoint="TOPLEFT">
                         <Offset><AbsDimension x="-2.5" y="5" /></Offset>
                     </Anchor>
                 </Anchors>
@@ -1105,7 +1105,7 @@
                     </Anchor>
                 </Anchors>
                 <Scripts><OnClick>KRT.Master:BtnSR(self, button)</OnClick></Scripts>
-            </Button>			
+            </Button>
 			<Button name="$parentFreeBtn" inherits="KRTButtonTemplate" text="Free">
 				<Size><AbsDimension x="35" y="25" /></Size>
 				<Anchors>

--- a/!KRT/Libs/LibDeformat-3.0.lua
+++ b/!KRT/Libs/LibDeformat-3.0.lua
@@ -18,7 +18,7 @@ end
 
 -- a dictionary of format to match entity
 local FORMAT_SEQUENCES = {
-    ["s"] = ".+",    
+    ["s"] = ".+",
     ["c"] = ".",
     ["%d*d"] = "%%-?%%d+",
     ["[fg]"] = "%%-?%%d+%%.?%%d*",
@@ -38,21 +38,21 @@ local function get_deformat_function(pattern)
     if func then
         return func
     end
-    
+
     -- escape the pattern, so that string.match can use it properly
     local unpattern = '^' .. pattern:gsub("([%(%)%.%*%+%-%[%]%?%^%$%%])", "%%%1") .. '$'
-    
+
     -- a dictionary of index-to-boolean representing whether the index is a number rather than a string.
     local number_indexes = {}
-    
+
     -- (if the pattern is a numbered format,) a dictionary of index-to-real index.
     local index_translation = nil
-    
+
     -- the highest found index, also the number of indexes found.
 	local highest_index
     if not pattern:find("%%1%$") then
         -- not a numbered format
-        
+
         local i = 0
         while true do
             i = i + 1
@@ -71,11 +71,11 @@ local function get_deformat_function(pattern)
             unpattern = unpattern:gsub("%%%%" .. first_sequence, "(" .. FORMAT_SEQUENCES[first_sequence] .. ")", 1)
             number_indexes[i] = not STRING_BASED_SEQUENCES[first_sequence]
         end
-        
+
         highest_index = i - 1
     else
         -- a numbered format
-        
+
         local i = 0
 		while true do
 		    i = i + 1
@@ -93,7 +93,7 @@ local function get_deformat_function(pattern)
 			number_indexes[i] = not STRING_BASED_SEQUENCES[found_sequence]
 		end
         highest_index = i - 1
-		
+
 		i = 0
 		index_translation = {}
 		pattern:gsub("%%(%d)%$", function(w)
@@ -101,7 +101,7 @@ local function get_deformat_function(pattern)
 		    index_translation[i] = tonumber(w)
 		end)
     end
-    
+
     if highest_index == 0 then
         cache[pattern] = do_nothing
     else
@@ -115,7 +115,7 @@ local function get_deformat_function(pattern)
                 end
                 return a1+0, a2
             end
-            
+
             -- or if it were a numbered pattern,
             local unpattern = ...
             return function(text)
@@ -126,12 +126,12 @@ local function get_deformat_function(pattern)
                 return a1+0, a2
             end
         ]=]
-        
+
         local t = {}
         t[#t+1] = [=[
             return function(text)
                 local ]=]
-        
+
         for i = 1, highest_index do
             if i ~= 1 then
                 t[#t+1] = ", "
@@ -143,25 +143,25 @@ local function get_deformat_function(pattern)
                 t[#t+1] = index_translation[i]
             end
         end
-        
+
         t[#t+1] = [=[ = text:match(]=]
         t[#t+1] = ("%q"):format(unpattern)
         t[#t+1] = [=[)
                 if not a1 then
                     return ]=]
-        
+
         for i = 1, highest_index do
             if i ~= 1 then
                 t[#t+1] = ", "
             end
             t[#t+1] = "nil"
         end
-        
+
         t[#t+1] = "\n"
         t[#t+1] = [=[
                 end
                 ]=]
-        
+
         t[#t+1] = "return "
         for i = 1, highest_index do
             if i ~= 1 then
@@ -177,14 +177,14 @@ local function get_deformat_function(pattern)
         t[#t+1] = [=[
             end
         ]=]
-        
+
         t = table.concat(t, "")
-        
+
         -- print(t)
-        
+
         cache[pattern] = assert(loadstring(t))()
     end
-    
+
     return cache[pattern]
 end
 
@@ -207,7 +207,7 @@ function LibDeformat.Deformat(text, pattern)
     elseif type(pattern) ~= "string" then
         error(("Argument #2 to `Deformat' must be a string, got %s (%s)."):format(type(pattern), pattern), 2)
     end
-    
+
     return get_deformat_function(pattern)(text)
 end
 
@@ -220,17 +220,17 @@ function LibDeformat.Test()
             return false, ...
         end
     end
-    
+
     local function check(text, pattern, ...)
         local success, results = tuple(pcall(LibDeformat.Deformat, text, pattern))
         if not success then
             return false, results
         end
-        
+
         if select('#', ...) ~= results.n then
             return false, ("Differing number of return values. Expected: %d. Actual: %d."):format(select('#', ...), results.n)
         end
-        
+
         for i = 1, results.n do
             local expected = select(i, ...)
             local actual = results[i]
@@ -240,17 +240,17 @@ function LibDeformat.Test()
                 return false, ("Return #%d differs. Expected: %s. Actual: %s"):format(expected, actual)
             end
         end
-        
+
         return true
     end
-    
+
     local function test(text, pattern, ...)
         local success, problem = check(text, pattern, ...)
         if not success then
             print(("Problem with (%q, %q): %s"):format(text, pattern, problem or ""))
         end
     end
-    
+
     test("Hello, friend", "Hello, %s", "friend")
     test("Hello, friend", "Hello, %1$s", "friend")
     test("Cost: $100", "Cost: $%d", 100)

--- a/!KRT/modules/Config.lua
+++ b/!KRT/modules/Config.lua
@@ -87,7 +87,7 @@ local Config = addon.Config
 		if not btn then return end
 		frameName = frameName or btn:GetParent():GetName()
 		local value, name = nil, btn:GetName()
-		addon:Debug("DEBUG", "Button clicked: %s", name)		
+		addon:Debug("DEBUG", "Button clicked: %s", name)
 		if name ~= frameName.."countdownDuration" then
 			value = (btn:GetChecked() == 1) or false
 			if name == frameName.."minimapButton" then
@@ -107,10 +107,10 @@ local Config = addon.Config
 
 	-- Localizing ui frame:
 	function LocalizeUIFrame()
-		if localized then 
+		if localized then
 			addon:Debug("DEBUG", "UI is already localized. Skipping.")
-			return 
-		end		
+			return
+		end
 		if GetLocale() ~= "enUS" and GetLocale() ~= "enGB" then
 			addon:Debug("DEBUG", "Setting localized UI strings.")
 			_G[frameName.."sortAscendingStr"]:SetText(L.StrConfigSortAscending)
@@ -130,7 +130,7 @@ local Config = addon.Config
 		end
 		_G[frameName.."Title"]:SetText(format(titleString, SETTINGS))
 		_G[frameName.."AboutStr"]:SetText(L.StrConfigAbout)
-		_G[frameName.."DefaultsBtn"]:SetScript("OnClick", LoadDefaultOptions)		
+		_G[frameName.."DefaultsBtn"]:SetScript("OnClick", LoadDefaultOptions)
 		addon:Debug("DEBUG", "UI frame localized.")
 		localized = true
 	end

--- a/!KRT/modules/Logger.lua
+++ b/!KRT/modules/Logger.lua
@@ -1369,7 +1369,7 @@ do
 
 		if isEdit and bossData ~= nil then
 			-- Use provided time or fallback to previous values:
-			if bTime == "" then 
+			if bTime == "" then
 				hour, minute = tempDate.hour, tempDate.min
 			else
 				hour, minute = match(bTime, "(%d+):(%d+)")

--- a/!KRT/modules/Master.lua
+++ b/!KRT/modules/Master.lua
@@ -132,13 +132,13 @@ local Master = addon.Master
 		end
 	end
 
-	function Master:BtnMS(btn) addon:Debug("DEBUG", "MS roll button pressed.") return AnnounceRoll(1, "ChatRollMS") 
+	function Master:BtnMS(btn) addon:Debug("DEBUG", "MS roll button pressed.") return AnnounceRoll(1, "ChatRollMS")
 	end
-	function Master:BtnOS(btn) addon:Debug("DEBUG", "OS roll button pressed.") return AnnounceRoll(2, "ChatRollOS") 
+	function Master:BtnOS(btn) addon:Debug("DEBUG", "OS roll button pressed.") return AnnounceRoll(2, "ChatRollOS")
 	end
-	function Master:BtnSR(btn) addon:Debug("DEBUG", "SR roll button pressed.") return AnnounceRoll(3, "ChatRollSR") 
+	function Master:BtnSR(btn) addon:Debug("DEBUG", "SR roll button pressed.") return AnnounceRoll(3, "ChatRollSR")
 	end
-	function Master:BtnFree(btn) addon:Debug("DEBUG", "Free roll button pressed.") return AnnounceRoll(4, "ChatRollFree") 
+	function Master:BtnFree(btn) addon:Debug("DEBUG", "Free roll button pressed.") return AnnounceRoll(4, "ChatRollFree")
 	end
 
 	function Master:BtnCountdown(btn)

--- a/!KRT/modules/Raid.lua
+++ b/!KRT/modules/Raid.lua
@@ -606,7 +606,7 @@ local Raid = addon.Raid
 		addon:Debug("DEBUG", "GetUnitID: name=%s, unitID=%s", tostring(resolvedName), tostring(id))
 		return id
 	end
-	
+
 	-----------------------
 	-- Raid & Loot Check --
 	-----------------------

--- a/!KRT/modules/Reserves.lua
+++ b/!KRT/modules/Reserves.lua
@@ -131,9 +131,9 @@ local Reserves = addon.Reserves
 		----------------------------------------------------------------
 		-- Localize UI Frame:
 		function LocalizeUIFrame()
-			if localized then 
+			if localized then
 				addon:Debug("DEBUG", "UI already localized.")
-				return 
+				return
 			end
 			if frameName then
 				_G[frameName.."Title"]:SetText(format(titleString, L.StrRaidReserves))


### PR DESCRIPTION
## Summary
- cleanup trailing whitespace in various Lua modules

## Testing
- `luacheck !KRT` *(fails: expected output shows existing code errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e8013b1a0832ebcacb6f79a7560e2