### PR TITLE
Format Lua modules and add stylua configuration

### DIFF
--- a/!KRT/modules/Changes.lua
+++ b/!KRT/modules/Changes.lua
@@ -296,3 +296,4 @@ local Changes = addon.Changes
 		_G[frameName.."Spec"]:ClearFocus()
 	end
 
+

--- a/!KRT/modules/Config.lua
+++ b/!KRT/modules/Config.lua
@@ -87,7 +87,7 @@ local Config = addon.Config
 		if not btn then return end
 		frameName = frameName or btn:GetParent():GetName()
 		local value, name = nil, btn:GetName()
-		addon:Debug("DEBUG", "Button clicked: %s", name)		
+		addon:Debug("DEBUG", "Button clicked: %s", name)
 		if name ~= frameName.."countdownDuration" then
 			value = (btn:GetChecked() == 1) or false
 			if name == frameName.."minimapButton" then
@@ -107,10 +107,10 @@ local Config = addon.Config
 
 	-- Localizing ui frame:
 	function LocalizeUIFrame()
-		if localized then 
+		if localized then
 			addon:Debug("DEBUG", "UI is already localized. Skipping.")
-			return 
-		end		
+			return
+		end
 		if GetLocale() ~= "enUS" and GetLocale() ~= "enGB" then
 			addon:Debug("DEBUG", "Setting localized UI strings.")
 			_G[frameName.."sortAscendingStr"]:SetText(L.StrConfigSortAscending)
@@ -130,7 +130,7 @@ local Config = addon.Config
 		end
 		_G[frameName.."Title"]:SetText(format(titleString, SETTINGS))
 		_G[frameName.."AboutStr"]:SetText(L.StrConfigAbout)
-		_G[frameName.."DefaultsBtn"]:SetScript("OnClick", LoadDefaultOptions)		
+		_G[frameName.."DefaultsBtn"]:SetScript("OnClick", LoadDefaultOptions)
 		addon:Debug("DEBUG", "UI frame localized.")
 		localized = true
 	end
@@ -173,4 +173,5 @@ local Config = addon.Config
 			end
 		end
 	end
+
 

--- a/!KRT/modules/Debugger.lua
+++ b/!KRT/modules/Debugger.lua
@@ -2,155 +2,156 @@ local addonName, addon = ...
 addon.Debugger = {}
 local Debugger = addon.Debugger
 
-    -- Local references
-    local frameName, frame, scrollFrame
-    local isDebuggerOpen = false
-    local buffer = {} -- Holds messages if the frame isn't ready
+	-- Local references
+	local frameName, frame, scrollFrame
+	local isDebuggerOpen = false
+	local buffer = {} -- Holds messages if the frame isn't ready
 
-    local logLevelPriority = { DEBUG = 1, INFO = 2, WARN = 3, ERROR = 4 }
-    local logLevelNames    = { [1] = "DEBUG", [2] = "INFO", [3] = "WARN", [4] = "ERROR" }
-    local minLevel = "DEBUG" -- Default log level
-    local MAX_DEBUG_LOGS = 500 -- <--- Limite massimo log, modifica qui
+	local logLevelPriority = { DEBUG = 1, INFO = 2, WARN = 3, ERROR = 4 }
+	local logLevelNames    = { [1] = "DEBUG", [2] = "INFO", [3] = "WARN", [4] = "ERROR" }
+	local minLevel = "DEBUG" -- Default log level
+	local MAX_DEBUG_LOGS = 500 -- <--- Limite massimo log, modifica qui
 
-    -- Called when the XML frame is loaded
-    function Debugger:OnLoad(self)
-        frame = self
-        frameName = frame:GetName()
-        scrollFrame = _G[frameName.."ScrollFrame"]
-        frame:SetMovable(true)
-        frame:EnableMouse(true)
-        frame:RegisterForDrag("LeftButton")
-        frame:SetScript("OnDragStart", frame.StartMoving)
-        frame:SetScript("OnDragStop", frame.StopMovingOrSizing)
+	-- Called when the XML frame is loaded
+	function Debugger:OnLoad(self)
+		frame = self
+		frameName = frame:GetName()
+		scrollFrame = _G[frameName.."ScrollFrame"]
+		frame:SetMovable(true)
+		frame:EnableMouse(true)
+		frame:RegisterForDrag("LeftButton")
+		frame:SetScript("OnDragStart", frame.StartMoving)
+		frame:SetScript("OnDragStop", frame.StopMovingOrSizing)
 
-        if scrollFrame then
-            print("[Debugger] scrollFrame found:", scrollFrame:GetName())
-        else
-            print("[Debugger] ERROR: scrollFrame is nil!")
-        end
+		if scrollFrame then
+			print("[Debugger] scrollFrame found:", scrollFrame:GetName())
+		else
+			print("[Debugger] ERROR: scrollFrame is nil!")
+		end
 
-        -- Restore saved position if available
-        if KRT_Debug and KRT_Debug.Pos and KRT_Debug.Pos.point then
-            local p = KRT_Debug.Pos
-            frame:ClearAllPoints()
-            frame:SetPoint(p.point, p.relativeTo or UIParent, p.relativePoint, p.xOfs, p.yOfs)
-        end
-    end
+		-- Restore saved position if available
+		if KRT_Debug and KRT_Debug.Pos and KRT_Debug.Pos.point then
+			local p = KRT_Debug.Pos
+			frame:ClearAllPoints()
+			frame:SetPoint(p.point, p.relativeTo or UIParent, p.relativePoint, p.xOfs, p.yOfs)
+		end
+	end
 
-    -- Show the debugger window
-    function Debugger:Show()
-        if not frame then return end
-        frame:Show()
+	-- Show the debugger window
+	function Debugger:Show()
+		if not frame then return end
+		frame:Show()
 
-        if not isDebuggerOpen then
-            isDebuggerOpen = true
-            self:Add("DEBUG", "Debugger window opened.")
-            self:AddBufferedMessages()
-        end
-    end
+		if not isDebuggerOpen then
+			isDebuggerOpen = true
+			self:Add("DEBUG", "Debugger window opened.")
+			self:AddBufferedMessages()
+		end
+	end
 
-    -- Hide the debugger window
-    function Debugger:Hide()
-        if frame then
-            frame:Hide()
-            isDebuggerOpen = false
-        end
-    end
+	-- Hide the debugger window
+	function Debugger:Hide()
+		if frame then
+			frame:Hide()
+			isDebuggerOpen = false
+		end
+	end
 
-    -- Clear the debug output
-    function Debugger:Clear()
-        if scrollFrame then
-            scrollFrame:Clear()
-        end
-        buffer = {}
-    end
+	-- Clear the debug output
+	function Debugger:Clear()
+		if scrollFrame then
+			scrollFrame:Clear()
+		end
+		buffer = {}
+	end
 
-    -- Set the minimum log level
-    function Debugger:SetMinLevel(level)
-        if type(level) == "number" and logLevelNames[level] then
-            minLevel = logLevelNames[level]
-            self:Add("INFO", "Log level set to [%s]", minLevel)
-        elseif type(level) == "string" then
-            level = string.upper(level)
-            if logLevelPriority[level] then
-                minLevel = level
-                self:Add("INFO", "Log level set to [%s]", minLevel)
-            else
-                self:Add("ERROR", "Invalid log level: %s", level)
-            end
-        else
-            self:Add("ERROR", "Invalid log level type.")
-        end
-    end
+	-- Set the minimum log level
+	function Debugger:SetMinLevel(level)
+		if type(level) == "number" and logLevelNames[level] then
+			minLevel = logLevelNames[level]
+			self:Add("INFO", "Log level set to [%s]", minLevel)
+		elseif type(level) == "string" then
+			level = string.upper(level)
+			if logLevelPriority[level] then
+				minLevel = level
+				self:Add("INFO", "Log level set to [%s]", minLevel)
+			else
+				self:Add("ERROR", "Invalid log level: %s", level)
+			end
+		else
+			self:Add("ERROR", "Invalid log level type.")
+		end
+	end
 
-    -- Get the current minimum log level
-    function Debugger:GetMinLevel()
-        return minLevel
-    end
+	-- Get the current minimum log level
+	function Debugger:GetMinLevel()
+		return minLevel
+	end
 
-    -- Add a message to the log (with optional level)
-    function Debugger:Add(level, msg, ...)
-        -- Allow call like Add("message") without level
-        if not msg then
-            msg = level
-            level = "DEBUG"
-        end
+	-- Add a message to the log (with optional level)
+	function Debugger:Add(level, msg, ...)
+		-- Allow call like Add("message") without level
+		if not msg then
+			msg = level
+			level = "DEBUG"
+		end
 
-        if logLevelPriority[level] < logLevelPriority[minLevel] then return end
+		if logLevelPriority[level] < logLevelPriority[minLevel] then return end
 
-        if select('#', ...) > 0 then
-            local safeArgs = {}
-            for i = 1, select('#', ...) do
-                local v = select(i, ...)
-                table.insert(safeArgs, type(v) == "string" and v or tostring(v))
-            end
-            msg = string.format(msg, unpack(safeArgs))
-        end
-        local line = string.format("[%s][%s] %s", date("%H:%M:%S"), level, msg)
+		if select('#', ...) > 0 then
+			local safeArgs = {}
+			for i = 1, select('#', ...) do
+				local v = select(i, ...)
+				table.insert(safeArgs, type(v) == "string" and v or tostring(v))
+			end
+			msg = string.format(msg, unpack(safeArgs))
+		end
+		local line = string.format("[%s][%s] %s", date("%H:%M:%S"), level, msg)
 
-        -- Se la finestra non è pronta
-        if not scrollFrame then
-            tinsert(buffer, line)
-            -- Limita la lunghezza del buffer!
-            while #buffer > MAX_DEBUG_LOGS do
-                table.remove(buffer, 1)
-            end
-            return
-        end
+		-- Se la finestra non è pronta
+		if not scrollFrame then
+			tinsert(buffer, line)
+			-- Limita la lunghezza del buffer!
+			while #buffer > MAX_DEBUG_LOGS do
+				table.remove(buffer, 1)
+			end
+			return
+		end
 
-        -- Scegli colore
-        local r, g, b = 1, 1, 1 -- default white
-        if level == "ERROR" then
-            r, g, b = 1, 0.2, 0.2
-        elseif level == "WARN" then
-            r, g, b = 1, 0.8, 0
-        elseif level == "INFO" then
-            r, g, b = 0.6, 0.8, 1
-        elseif level == "DEBUG" then
-            r, g, b = 0.8, 0.8, 0.8
-        end
+		-- Scegli colore
+		local r, g, b = 1, 1, 1 -- default white
+		if level == "ERROR" then
+			r, g, b = 1, 0.2, 0.2
+		elseif level == "WARN" then
+			r, g, b = 1, 0.8, 0
+		elseif level == "INFO" then
+			r, g, b = 0.6, 0.8, 1
+		elseif level == "DEBUG" then
+			r, g, b = 0.8, 0.8, 0.8
+		end
 
-        scrollFrame:AddMessage(line, r, g, b)
+		scrollFrame:AddMessage(line, r, g, b)
 
-        -- [OPZIONALE] Se hai una tabella di log persistente, tronca anche quella
-        if KRT_Debug and KRT_Debug.Debugs then
-            table.insert(KRT_Debug.Debugs, line)
-            while #KRT_Debug.Debugs > MAX_DEBUG_LOGS do
-                table.remove(KRT_Debug.Debugs, 1)
-            end
-        end
-    end
+		-- [OPZIONALE] Se hai una tabella di log persistente, tronca anche quella
+		if KRT_Debug and KRT_Debug.Debugs then
+			table.insert(KRT_Debug.Debugs, line)
+			while #KRT_Debug.Debugs > MAX_DEBUG_LOGS do
+				table.remove(KRT_Debug.Debugs, 1)
+			end
+		end
+	end
 
-    -- Replay any buffered messages
-    function Debugger:AddBufferedMessages()
-        for _, msg in ipairs(buffer) do
-            scrollFrame:AddMessage(msg)
-        end
-        buffer = {}
-    end
+	-- Replay any buffered messages
+	function Debugger:AddBufferedMessages()
+		for _, msg in ipairs(buffer) do
+			scrollFrame:AddMessage(msg)
+		end
+		buffer = {}
+	end
 
-    -- Returns true if debugger is visible
-    function Debugger:IsShown()
-        return frame and frame:IsShown()
-    end
+	-- Returns true if debugger is visible
+	function Debugger:IsShown()
+		return frame and frame:IsShown()
+	end
+
 

--- a/!KRT/modules/Logger.lua
+++ b/!KRT/modules/Logger.lua
@@ -957,11 +957,11 @@ do
 				end
 			end
 			-- We delete all the loot from that player:
-                        for i = #raid.loot, 1, -1 do
-                                if raid.loot[i].bossNum == selectedPlayer then
-                                        tremove(raid.loot, i)
-                                end
-                        end
+						for i = #raid.loot, 1, -1 do
+								if raid.loot[i].bossNum == selectedPlayer then
+										tremove(raid.loot, i)
+								end
+						end
 			fetched = false
 		end
 
@@ -1369,7 +1369,7 @@ do
 
 		if isEdit and bossData ~= nil then
 			-- Use provided time or fallback to previous values:
-			if bTime == "" then 
+			if bTime == "" then
 				hour, minute = tempDate.hour, tempDate.min
 			else
 				hour, minute = match(bTime, "(%d+):(%d+)")
@@ -1531,4 +1531,5 @@ do
 		addon:PrintError(L.ErrAttendeesNotFound or "Player not in raid")
 		addon.Logger.BossAttendees:Fetch()
 	end
+
 

--- a/!KRT/modules/Loot.lua
+++ b/!KRT/modules/Loot.lua
@@ -193,3 +193,4 @@ local Loot = addon.Loot
 		return false
 	end
 
+

--- a/!KRT/modules/Master.lua
+++ b/!KRT/modules/Master.lua
@@ -88,13 +88,13 @@ local Master = addon.Master
 		end
 	end
 
-    -- Button: Open List
+	-- Button: Open List
 	function Master:BtnOpenReserves(btn)
 		addon:Debug("DEBUG", "Opening reserves list.")
 		addon.Reserves:ShowWindow()
 	end
 
-    -- Button: Import Reserve
+	-- Button: Import Reserve
 	function Master:BtnImportReserves(btn)
 		addon:Debug("DEBUG", "Importing reserves.")
 		addon.Reserves:ShowImportBox()
@@ -132,13 +132,13 @@ local Master = addon.Master
 		end
 	end
 
-	function Master:BtnMS(btn) addon:Debug("DEBUG", "MS roll button pressed.") return AnnounceRoll(1, "ChatRollMS") 
+	function Master:BtnMS(btn) addon:Debug("DEBUG", "MS roll button pressed.") return AnnounceRoll(1, "ChatRollMS")
 	end
-	function Master:BtnOS(btn) addon:Debug("DEBUG", "OS roll button pressed.") return AnnounceRoll(2, "ChatRollOS") 
+	function Master:BtnOS(btn) addon:Debug("DEBUG", "OS roll button pressed.") return AnnounceRoll(2, "ChatRollOS")
 	end
-	function Master:BtnSR(btn) addon:Debug("DEBUG", "SR roll button pressed.") return AnnounceRoll(3, "ChatRollSR") 
+	function Master:BtnSR(btn) addon:Debug("DEBUG", "SR roll button pressed.") return AnnounceRoll(3, "ChatRollSR")
 	end
-	function Master:BtnFree(btn) addon:Debug("DEBUG", "Free roll button pressed.") return AnnounceRoll(4, "ChatRollFree") 
+	function Master:BtnFree(btn) addon:Debug("DEBUG", "Free roll button pressed.") return AnnounceRoll(4, "ChatRollFree")
 	end
 
 	function Master:BtnCountdown(btn)
@@ -777,4 +777,5 @@ local Master = addon.Master
 			announced = false
 		end
 	end)
+
 

--- a/!KRT/modules/Minimap.lua
+++ b/!KRT/modules/Minimap.lua
@@ -170,3 +170,4 @@ local Minimap = addon.Minimap
 		return KRT_MINIMAP_GUI:Hide()
 	end
 
+

--- a/!KRT/modules/Raid.lua
+++ b/!KRT/modules/Raid.lua
@@ -606,7 +606,7 @@ local Raid = addon.Raid
 		addon:Debug("DEBUG", "GetUnitID: name=%s, unitID=%s", tostring(resolvedName), tostring(id))
 		return id
 	end
-	
+
 	-----------------------
 	-- Raid & Loot Check --
 	-----------------------
@@ -648,4 +648,5 @@ local Raid = addon.Raid
 		end
 		addon:Debug("DEBUG", "ClearRaidIcons: Cleared icons for %d players", #players)
 	end
+
 

--- a/!KRT/modules/Reserves.lua
+++ b/!KRT/modules/Reserves.lua
@@ -131,9 +131,9 @@ local Reserves = addon.Reserves
 		----------------------------------------------------------------
 		-- Localize UI Frame:
 		function LocalizeUIFrame()
-			if localized then 
+			if localized then
 				addon:Debug("DEBUG", "UI already localized.")
-				return 
+				return
 			end
 			if frameName then
 				_G[frameName.."Title"]:SetText(format(titleString, L.StrRaidReserves))
@@ -575,4 +575,5 @@ local Reserves = addon.Reserves
 			addon:Debug("DEBUG", "Players for itemId %d: %s", itemId, table.concat(list, ", "))
 			return #list > 0 and table.concat(list, ", ") or ""
 		end
+
 

--- a/!KRT/modules/Rolls.lua
+++ b/!KRT/modules/Rolls.lua
@@ -344,3 +344,4 @@ local Rolls = addon.Rolls
 		addon:Debug("DEBUG", "FetchRolls completed. Total entries: %d", rollsCount)
 	end
 
+

--- a/!KRT/modules/Spammer.lua
+++ b/!KRT/modules/Spammer.lua
@@ -329,3 +329,4 @@ local Spammer = addon.Spammer
 	end)
 end
 
+

--- a/!KRT/modules/Utils.lua
+++ b/!KRT/modules/Utils.lua
@@ -37,16 +37,16 @@ end
 -- DeepCopy:
 _G.table.deepCopy = function(t)
 	if type(t) ~= "table" then return t end
-    local mt = getmetatable(t)
-    local res = {}
-    for k, v in pairs(t) do
-        if type(v) == "table" then
-            v = _G.table.deepCopy(v)
-        end
-        res[k] = v
-    end
-    setmetatable(res, mt)
-    return res
+	local mt = getmetatable(t)
+	local res = {}
+	for k, v in pairs(t) do
+		if type(v) == "table" then
+			v = _G.table.deepCopy(v)
+		end
+		res[k] = v
+	end
+	setmetatable(res, mt)
+	return res
 end
 
 -- Reverse table:

--- a/!KRT/modules/Warnings.lua
+++ b/!KRT/modules/Warnings.lua
@@ -239,3 +239,4 @@ local Warnings = addon.Warnings
 		fetched = true
 	end
 
+

--- a/!KRT/modules/bossList.lua
+++ b/!KRT/modules/bossList.lua
@@ -3,120 +3,120 @@
 local KRT = _G["KRT"]
 
 if not KRT then
-    -- This should ideally not happen if the .toc load order is correct,
-    -- but it's a good defensive check.
-    error("KRT global table not found when loading bossList.lua")
+	-- This should ideally not happen if the .toc load order is correct,
+	-- but it's a good defensive check.
+	error("KRT global table not found when loading bossList.lua")
 end
 
 -- List of bosses IDs to track:
 KRT.bossListIDs = {
-    -- Karazhan (10 giocatori)
-    [16152] = "Attumen the Huntsman",
-    [16457] = "Maiden of Virtue",
-    [15687] = "Moroes",
-    [15691] = "The Curator",
-    [15688] = "Terestian Illhoof",
-    [16524] = "Shade of Aran",
-    [15689] = "Netherspite",
-    [15690] = "Prince Malchezaar",
-    [17225] = "Nightbane",
-    -- Gruul's Lair (25 giocatori)
-    [18831] = "High King Maulgar",
-    [19044] = "Gruul the Dragonkiller",
-    -- Magtheridon's Lair (25 giocatori)
-    [17257] = "Magtheridon",
-    -- Serpentshrine Cavern (25 giocatori)
-    [21216] = "Hydross the Unstable",
-    [21217] = "The Lurker Below",
-    [21215] = "Leotheras the Blind",
-    [21214] = "Fathom-Lord Karathress",
-    [21213] = "Morogrim Tidewalker",
-    [21212] = "Lady Vashj",
-    -- The Eye (Tempest Keep) (25 giocatori)
-    [19514] = "Al'ar",
-    [19516] = "Void Reaver",
-    [18805] = "High Astromancer Solarian",
-    [19622] = "Kael'thas Sunstrider",
-    -- Battle for Mount Hyjal (25 giocatori)
-    [17767] = "Rage Winterchill",
-    [17808] = "Anetheron",
-    [17888] = "Kaz'rogal",
-    [17842] = "Azgalor",
-    [17968] = "Archimonde",
-    -- Black Temple (25 giocatori)
-    [22887] = "High Warlord Naj'entus",
-    [22898] = "Supremus",
-    [22841] = "Shade of Akama",
-    [22871] = "Teron'khan",
-    [22948] = "Gurtogg Bloodboil",
-    [23420] = "Reliquary of Souls",
-    [22947] = "Mother Shahraz",
-    [22949] = "Illidari Council",
-    [22917] = "Illidan Stormrage",
-    -- Sunwell Plateau (25 giocatori)
-    [24850] = "Kalecgos",
-    [24882] = "Brutallus",
-    [25038] = "Felmyst",
-    [25165] = "Eredar Twins",
-    [25741] = "M'uru",
-    [25315] = "Kil'jaeden",
-    -- Zul'Aman (10 giocatori)
-    [23574] = "Nalorakk",
-    [23576] = "Jan'alai",
-    [23578] = "Akil'zon",
-    [23577] = "Halazzi",
-    [24239] = "Hex Lord Malacrass",
-    [23863] = "Zul'jin",
-    -- World Bosses
-    [18728] = "Doom Lord Kazzak",
-    [17711] = "Doomwalker",
-    -- Naxxramas:
-    [15956] = "Anub'Rekhan",
-    [15953] = "Grand Widow Faerlina",
-    [15952] = "Maexxna",
-    [15954] = "Noth the Plaguebringer",
-    [15936] = "Heigan the Unclean",
-    [16011] = "Loatheb",
-    [16061] = "Instructor Razuvious",
-    [16060] = "Gothik the Harvester",
-    [16028] = "Patchwerk",
-    [15931] = "Grobbulus",
-    [15932] = "Gluth",
-    [15928] = "Thaddius",
-    [15989] = "Sapphiron",
-    [15990] = "Kel'Thuzad",
-    -- The Obsidian Sanctum:
-    [28860] = "Sartharion",
-    -- Eye of Eternity:
-    [28859] = "Malygos",
-    -- Archavon's Chamber:
-    [31125] = "Archavon the Stone Watcher",
-    [33993] = "Emalon the Storm Watcher",
-    [35013] = "Koralon the Flame Watcher",
-    [38433] = "Toravon the Ice Watcher",
-    -- Ulduar
-    [33113] = "Flame Leviathan",
-    [33118] = "Ignis the Furnace Master",
-    [33186] = "Razorscale",
-    [33293] = "XT-002 Deconstructor",
-    [32930] = "Kologarn",
-    [33515] = "Auriaya",
-    [33271] = "General Vezax",
-    [33288] = "Yogg-Saron",
-    -- Onyxia's Lair:
-    [10184] = "Onyxia",
-    -- Trial of the Crusader:
-    [34797] = "Icehowl",
-    [34780] = "Lord Jaraxxus",
-    [34564] = "Anub'arak",
-    -- Icecrown Citadel:
-    [36612] = "Lord Marrowgar",
-    [36855] = "Lady Deathwhisper",
-    [37813] = "Deathbringer Saurfang",
-    [36626] = "Festergut",
-    [36627] = "Rotface",
-    [36678] = "Professor Putricide",
-    [37955] = "Blood-Queen Lana'thel",
-    [36853] = "Sindragosa",
-    [36597] = "The Lich King"
+	-- Karazhan (10 giocatori)
+	[16152] = "Attumen the Huntsman",
+	[16457] = "Maiden of Virtue",
+	[15687] = "Moroes",
+	[15691] = "The Curator",
+	[15688] = "Terestian Illhoof",
+	[16524] = "Shade of Aran",
+	[15689] = "Netherspite",
+	[15690] = "Prince Malchezaar",
+	[17225] = "Nightbane",
+	-- Gruul's Lair (25 giocatori)
+	[18831] = "High King Maulgar",
+	[19044] = "Gruul the Dragonkiller",
+	-- Magtheridon's Lair (25 giocatori)
+	[17257] = "Magtheridon",
+	-- Serpentshrine Cavern (25 giocatori)
+	[21216] = "Hydross the Unstable",
+	[21217] = "The Lurker Below",
+	[21215] = "Leotheras the Blind",
+	[21214] = "Fathom-Lord Karathress",
+	[21213] = "Morogrim Tidewalker",
+	[21212] = "Lady Vashj",
+	-- The Eye (Tempest Keep) (25 giocatori)
+	[19514] = "Al'ar",
+	[19516] = "Void Reaver",
+	[18805] = "High Astromancer Solarian",
+	[19622] = "Kael'thas Sunstrider",
+	-- Battle for Mount Hyjal (25 giocatori)
+	[17767] = "Rage Winterchill",
+	[17808] = "Anetheron",
+	[17888] = "Kaz'rogal",
+	[17842] = "Azgalor",
+	[17968] = "Archimonde",
+	-- Black Temple (25 giocatori)
+	[22887] = "High Warlord Naj'entus",
+	[22898] = "Supremus",
+	[22841] = "Shade of Akama",
+	[22871] = "Teron'khan",
+	[22948] = "Gurtogg Bloodboil",
+	[23420] = "Reliquary of Souls",
+	[22947] = "Mother Shahraz",
+	[22949] = "Illidari Council",
+	[22917] = "Illidan Stormrage",
+	-- Sunwell Plateau (25 giocatori)
+	[24850] = "Kalecgos",
+	[24882] = "Brutallus",
+	[25038] = "Felmyst",
+	[25165] = "Eredar Twins",
+	[25741] = "M'uru",
+	[25315] = "Kil'jaeden",
+	-- Zul'Aman (10 giocatori)
+	[23574] = "Nalorakk",
+	[23576] = "Jan'alai",
+	[23578] = "Akil'zon",
+	[23577] = "Halazzi",
+	[24239] = "Hex Lord Malacrass",
+	[23863] = "Zul'jin",
+	-- World Bosses
+	[18728] = "Doom Lord Kazzak",
+	[17711] = "Doomwalker",
+	-- Naxxramas:
+	[15956] = "Anub'Rekhan",
+	[15953] = "Grand Widow Faerlina",
+	[15952] = "Maexxna",
+	[15954] = "Noth the Plaguebringer",
+	[15936] = "Heigan the Unclean",
+	[16011] = "Loatheb",
+	[16061] = "Instructor Razuvious",
+	[16060] = "Gothik the Harvester",
+	[16028] = "Patchwerk",
+	[15931] = "Grobbulus",
+	[15932] = "Gluth",
+	[15928] = "Thaddius",
+	[15989] = "Sapphiron",
+	[15990] = "Kel'Thuzad",
+	-- The Obsidian Sanctum:
+	[28860] = "Sartharion",
+	-- Eye of Eternity:
+	[28859] = "Malygos",
+	-- Archavon's Chamber:
+	[31125] = "Archavon the Stone Watcher",
+	[33993] = "Emalon the Storm Watcher",
+	[35013] = "Koralon the Flame Watcher",
+	[38433] = "Toravon the Ice Watcher",
+	-- Ulduar
+	[33113] = "Flame Leviathan",
+	[33118] = "Ignis the Furnace Master",
+	[33186] = "Razorscale",
+	[33293] = "XT-002 Deconstructor",
+	[32930] = "Kologarn",
+	[33515] = "Auriaya",
+	[33271] = "General Vezax",
+	[33288] = "Yogg-Saron",
+	-- Onyxia's Lair:
+	[10184] = "Onyxia",
+	-- Trial of the Crusader:
+	[34797] = "Icehowl",
+	[34780] = "Lord Jaraxxus",
+	[34564] = "Anub'arak",
+	-- Icecrown Citadel:
+	[36612] = "Lord Marrowgar",
+	[36855] = "Lady Deathwhisper",
+	[37813] = "Deathbringer Saurfang",
+	[36626] = "Festergut",
+	[36627] = "Rotface",
+	[36678] = "Professor Putricide",
+	[37955] = "Blood-Queen Lana'thel",
+	[36853] = "Sindragosa",
+	[36597] = "The Lich King"
 }

--- a/!KRT/modules/ignoredItems.lua
+++ b/!KRT/modules/ignoredItems.lua
@@ -3,71 +3,71 @@
 local KRT = _G["KRT"]
 
 if not KRT then
-    -- This should ideally not happen if the .toc load order is correct,
-    -- but it's a good defensive check.
-    error("KRT global table not found when loading ignoredItems.lua")
+	-- This should ideally not happen if the .toc load order is correct,
+	-- but it's a good defensive check.
+	error("KRT global table not found when loading ignoredItems.lua")
 end
 
 -- Items to ignore when adding raids loot:
 KRT.ignoredItems = {
-    -- Emblems (Wrath of the Lich King)
-    [40752] = true,  -- Emblem of Heroism
-    [40753] = true,  -- Emblem of Valor
-    [45624] = true,  -- Emblem of Conquest
-    [47241] = true,  -- Emblem of Triumph
-    [49426] = true,  -- Emblem of Frost
-    -- Emblems and Tokens (The Burning Crusade)
-    [29434] = true,  -- Badge of Justice
-    [29736] = true,  -- Arcane Tome
-    [29737] = true,  -- Firewing Signet
-    [29738] = true,  -- Fel Armament
-    [29739] = true,  -- Sunfury Signet
-    [29740] = true,  -- Mark of Sargeras
-    [29741] = true,  -- Fel Armament
-    -- High-end Gems
-    [36931] = true,  -- Ametrine
-    [36919] = true,  -- Cardinal Ruby
-    [36928] = true,  -- Dreadstone
-    [36934] = true,  -- Eye of Zul
-    [36922] = true,  -- King's Amber
-    [36925] = true,  -- Majestic Zircon
-    -- Enchanting Materials - Classic
-    [10940] = true,  -- Strange Dust
-    [10938] = true,  -- Lesser Magic Essence
-    [10939] = true,  -- Greater Magic Essence
-    [10978] = true,  -- Small Glimmering Shard
-    [10998] = true,  -- Lesser Astral Essence
-    [11082] = true,  -- Greater Astral Essence
-    [11083] = true,  -- Soul Dust
-    [11084] = true,  -- Large Glimmering Shard
-    [11134] = true,  -- Lesser Mystic Essence
-    [11135] = true,  -- Greater Mystic Essence
-    [11137] = true,  -- Vision Dust
-    [11138] = true,  -- Small Glowing Shard
-    [11139] = true,  -- Large Glowing Shard
-    [11174] = true,  -- Lesser Nether Essence
-    [11175] = true,  -- Greater Nether Essence
-    [11176] = true,  -- Dream Dust
-    [11177] = true,  -- Small Radiant Shard
-    [11178] = true,  -- Large Radiant Shard
-    [14343] = true,  -- Small Brilliant Shard
-    [14344] = true,  -- Large Brilliant Shard
-    [16202] = true,  -- Lesser Eternal Essence
-    [16203] = true,  -- Greater Eternal Essence
-    [16204] = true,  -- Illusion Dust
-    [20725] = true,  -- Nexus Crystal
-    -- Enchanting Materials - The Burning Crusade
-    [22445] = true,  -- Arcane Dust
-    [22446] = true,  -- Greater Planar Essence
-    [22447] = true,  -- Lesser Planar Essence
-    [22448] = true,  -- Small Prismatic Shard
-    [22449] = true,  -- Large Prismatic Shard
-    [22450] = true,  -- Void Crystal
-    -- Enchanting Materials - Wrath of the Lich King
-    [34052] = true,  -- Dream Shard
-    [34053] = true,  -- Small Dream Shard
-    [34054] = true,  -- Infinite Dust
-    [34055] = true,  -- Greater Cosmic Essence
-    [34056] = true,  -- Lesser Cosmic Essence
-    [34057] = true,  -- Abyss Crystal
+	-- Emblems (Wrath of the Lich King)
+	[40752] = true,  -- Emblem of Heroism
+	[40753] = true,  -- Emblem of Valor
+	[45624] = true,  -- Emblem of Conquest
+	[47241] = true,  -- Emblem of Triumph
+	[49426] = true,  -- Emblem of Frost
+	-- Emblems and Tokens (The Burning Crusade)
+	[29434] = true,  -- Badge of Justice
+	[29736] = true,  -- Arcane Tome
+	[29737] = true,  -- Firewing Signet
+	[29738] = true,  -- Fel Armament
+	[29739] = true,  -- Sunfury Signet
+	[29740] = true,  -- Mark of Sargeras
+	[29741] = true,  -- Fel Armament
+	-- High-end Gems
+	[36931] = true,  -- Ametrine
+	[36919] = true,  -- Cardinal Ruby
+	[36928] = true,  -- Dreadstone
+	[36934] = true,  -- Eye of Zul
+	[36922] = true,  -- King's Amber
+	[36925] = true,  -- Majestic Zircon
+	-- Enchanting Materials - Classic
+	[10940] = true,  -- Strange Dust
+	[10938] = true,  -- Lesser Magic Essence
+	[10939] = true,  -- Greater Magic Essence
+	[10978] = true,  -- Small Glimmering Shard
+	[10998] = true,  -- Lesser Astral Essence
+	[11082] = true,  -- Greater Astral Essence
+	[11083] = true,  -- Soul Dust
+	[11084] = true,  -- Large Glimmering Shard
+	[11134] = true,  -- Lesser Mystic Essence
+	[11135] = true,  -- Greater Mystic Essence
+	[11137] = true,  -- Vision Dust
+	[11138] = true,  -- Small Glowing Shard
+	[11139] = true,  -- Large Glowing Shard
+	[11174] = true,  -- Lesser Nether Essence
+	[11175] = true,  -- Greater Nether Essence
+	[11176] = true,  -- Dream Dust
+	[11177] = true,  -- Small Radiant Shard
+	[11178] = true,  -- Large Radiant Shard
+	[14343] = true,  -- Small Brilliant Shard
+	[14344] = true,  -- Large Brilliant Shard
+	[16202] = true,  -- Lesser Eternal Essence
+	[16203] = true,  -- Greater Eternal Essence
+	[16204] = true,  -- Illusion Dust
+	[20725] = true,  -- Nexus Crystal
+	-- Enchanting Materials - The Burning Crusade
+	[22445] = true,  -- Arcane Dust
+	[22446] = true,  -- Greater Planar Essence
+	[22447] = true,  -- Lesser Planar Essence
+	[22448] = true,  -- Small Prismatic Shard
+	[22449] = true,  -- Large Prismatic Shard
+	[22450] = true,  -- Void Crystal
+	-- Enchanting Materials - Wrath of the Lich King
+	[34052] = true,  -- Dream Shard
+	[34053] = true,  -- Small Dream Shard
+	[34054] = true,  -- Infinite Dust
+	[34055] = true,  -- Greater Cosmic Essence
+	[34056] = true,  -- Lesser Cosmic Essence
+	[34057] = true,  -- Abyss Crystal
 }

--- a/stylua.py
+++ b/stylua.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import sys, glob, re
+
+
+def parse_config(path):
+    cfg = {}
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '=' not in line:
+                continue
+            key, value = line.split('=', 1)
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if value.lower() in ('true', 'false'):
+                cfg[key] = value.lower() == 'true'
+            else:
+                try:
+                    cfg[key] = int(value)
+                except ValueError:
+                    cfg[key] = value
+    return cfg
+
+
+def format_file(path, cfg):
+    with open(path, 'rb') as f:
+        data = f.read()
+    has_final_nl = data.endswith(b'\n')
+    text = data.decode('utf-8').replace('\r\n', '\n').replace('\r', '\n')
+    lines = text.split('\n')
+    indent_width = int(cfg.get('indent_width', 4))
+    indent_type = cfg.get('indent_type', 'Tabs')
+    formatted = []
+    for line in lines:
+        stripped = line.rstrip()
+        if indent_type.lower() == 'tabs':
+            match = re.match(r'^[ ]+', stripped)
+            if match:
+                spaces = len(match.group(0))
+                tab_count = spaces // indent_width
+                extra_spaces = spaces % indent_width
+                stripped = '\t' * tab_count + ' ' * extra_spaces + stripped[spaces:]
+        formatted.append(stripped)
+    out_text = '\n'.join(formatted)
+    if has_final_nl:
+        out_bytes = (out_text + '\n').encode('utf-8')
+    else:
+        out_bytes = out_text.encode('utf-8')
+    if out_bytes != data:
+        with open(path, 'wb') as f:
+            f.write(out_bytes)
+
+
+def main():
+    args = sys.argv[1:]
+    cfg_path = None
+    pattern = None
+    i = 0
+    while i < len(args):
+        if args[i] == '--config-path':
+            cfg_path = args[i+1]
+            i += 2
+        else:
+            pattern = args[i]
+            i += 1
+    if not cfg_path or not pattern:
+        print('Usage: stylua --config-path <path> <pattern>')
+        return 1
+    cfg = parse_config(cfg_path)
+    for file in glob.glob(pattern):
+        format_file(file, cfg)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,4 @@
+indent_type = "Tabs"
+indent_width = 4
+line_endings = "Unix"
+insert_final_newline = false


### PR DESCRIPTION
## Summary
- add a simple `stylua.py` formatter to mimic stylua
- add `stylua.toml` configuration matching `.editorconfig`
- format all Lua modules under `!KRT/modules`

## Testing
- `python3 stylua.py --config-path stylua.toml '!KRT/modules/*.lua'`

------
https://chatgpt.com/codex/tasks/task_e_684f01df3bc8832e9af01b2ab46d5041