### PR TITLE
Remove extraneous end in Spammer.lua

### DIFF
--- a/!KRT/modules/Spammer.lua
+++ b/!KRT/modules/Spammer.lua
@@ -327,5 +327,4 @@ local Spammer = addon.Spammer
 	spamFrame:SetScript("OnUpdate", function(self, elapsed)
 		if UISpammer then UpdateUIFrame(UISpammer, elapsed) end
 	end)
-end
 


### PR DESCRIPTION
## Summary
- fix stray `end` in `Spammer.lua`

## Testing
- `luac -p '!KRT/modules/Spammer.lua'`


------
https://chatgpt.com/codex/tasks/task_e_685045ec01c0832e9ca64a3d76598c54