### PR TITLE
Fix do block closure in Logger

### DIFF
--- a/!KRT/modules/Logger.lua
+++ b/!KRT/modules/Logger.lua
@@ -236,7 +236,6 @@ local Logger = addon.Logger
 		addon.Logger.selectedPlayer = nil
 		addon.Logger.selectedItem   = nil
 	end)
-end
 
 -- Logger Raids List:
 do
@@ -1529,6 +1528,8 @@ do
 			end
 		end
 		addon:PrintError(L.ErrAttendeesNotFound or "Player not in raid")
-		addon.Logger.BossAttendees:Fetch()
-	end
+                addon.Logger.BossAttendees:Fetch()
+        end
+
+end
 


### PR DESCRIPTION
## Summary
- close AttendeesBox do-block in Logger.lua
- fix syntax by removing stray `end`

## Testing
- `luac -p '!KRT/modules/Logger.lua'`

------
https://chatgpt.com/codex/tasks/task_e_685045e47b04832ea85cfe440a6030ed