### PR TITLE
Use LibBossIDs for boss detection

### DIFF
--- a/!KRT/!KRT.toc
+++ b/!KRT/!KRT.toc
@@ -5,7 +5,7 @@
 ## Author: Kader (|cff808080bkader#5341|r)
 ## DefaultState: enabled
 ## SavedVariables: KRT_Options, KRT_Raids, KRT_Players, KRT_CurrentRaid, KRT_LastBoss, KRT_NextReset, KRT_Warnings, KRT_Spammer, KRT_ExportString, KRT_SavedReserves, KRT_Debug
-## Version: 0.5.6b
+## Version: 0.5.6c
 ## X-Date: 2022-06-03 @ 11:10 PM |cff808080UTC|r
 ## X-Category: Raid, Inventory
 ## X-License: MIT/X
@@ -17,6 +17,7 @@
 # Libraries:
 Libs\LibStub.lua
 Libs\LibDeformat-3.0.lua
+Libs\LibBossIDs-1.0.lua
 
 # Localization (moved to the top for 'L' to be available):
 Localization\localization.en.lua
@@ -43,4 +44,3 @@ KRT.xml
 
 # Modules
 modules\ignoredItems.lua
-modules\bossList.lua

--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -98,6 +98,7 @@ local format, match, find, strlen = string.format, string.match, string.find, st
 local strsub, gsub, lower, upper = string.sub, string.gsub, string.lower, string.upper
 local tostring, tonumber, ucfirst = tostring, tonumber, _G.string.ucfirst
 local deformat = LibStub("LibDeformat-3.0")
+local BossIDs = LibStub("LibBossIDs-1.0").BossIDs
 
 -- Returns the used frame's name:
 function addon:GetFrameName()
@@ -610,8 +611,8 @@ function addon:COMBAT_LOG_EVENT_UNFILTERED(...)
 	local _, event, _, _, _, destGUID, destName = ...
 	if not KRT_CurrentRaid then return end
 	if event == "UNIT_DIED" then
-		local npcID = Utils.GetNPCID(destGUID)
-		if addon.bossListIDs[npcID] then
+               local npcID = Utils.GetNPCID(destGUID)
+               if BossIDs[npcID] then
 			if KRT then
 				addon:Debug("INFO", "Boss killed: %s", destName)
 			end

--- a/!KRT/Libs/LibBossIDs-1.0.lua
+++ b/!KRT/Libs/LibBossIDs-1.0.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Name: LibBossIDs-1.0
 Revision: $Revision: 44 $
 Author: Elsia


### PR DESCRIPTION
## Summary
- add LibBossIDs to addon toc
- load LibBossIDs in main addon file
- rely on library boss table in combat log handler
- remove UTF-8 BOM from LibBossIDs library file

## Testing
- `luacheck '!KRT'`

------
https://chatgpt.com/codex/tasks/task_e_685275265dac832ea8635bf65e1db15c