### PR TITLE
Clamp raid player counts to non-negative values

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -660,27 +660,33 @@ do
 		return 0
 	end
 
-	function Raid:SetPlayerCount(name, value, raidNum)
-		raidNum = raidNum or KRT_CurrentRaid
-		local players = KRT_Raids[raidNum] and KRT_Raids[raidNum].players
-		if not players then return end
-		for i, p in ipairs(players) do
-			if p.name == name then
-				p.count = value
-				return
-			end
-		end
-	end
+        function Raid:SetPlayerCount(name, value, raidNum)
+                raidNum = raidNum or KRT_CurrentRaid
+
+                -- Prevent setting a negative count
+                if value < 0 then
+                        return
+                end
+
+                local players = KRT_Raids[raidNum] and KRT_Raids[raidNum].players
+                if not players then return end
+                for i, p in ipairs(players) do
+                        if p.name == name then
+                                p.count = value
+                                return
+                        end
+                end
+        end
 
 	function Raid:IncrementPlayerCount(name, raidNum)
 		local c = Raid:GetPlayerCount(name, raidNum)
 		Raid:SetPlayerCount(name, c + 1, raidNum)
 	end
 
-	function Raid:DecrementPlayerCount(name, raidNum)
-		local c = Raid:GetPlayerCount(name, raidNum)
-		Raid:SetPlayerCount(name, c - 1, raidNum)
-	end
+        function Raid:DecrementPlayerCount(name, raidNum)
+                local c = Raid:GetPlayerCount(name, raidNum)
+                Raid:SetPlayerCount(name, math.max(0, c - 1), raidNum)
+        end
 
 	--------------------
 	-- Raid Functions --


### PR DESCRIPTION
## Summary
- Guard Raid:SetPlayerCount against negative inputs
- Clamp Raid:DecrementPlayerCount so counts never dip below zero

## Testing
- `luac -p '!KRT/KRT.lua'`
- `luacheck '!KRT/KRT.lua'`
- `lua /tmp/test.lua`


------
https://chatgpt.com/codex/tasks/task_e_688e65e4bf64832e86bf499dc396a0ee