### PR TITLE
Validate player counts before updating

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -665,6 +665,7 @@ do
 
                 -- Prevent setting a negative count
                 if value < 0 then
+                        addon:PrintError(L.ErrPlayerCountBelowZero:format(name))
                         return
                 end
 
@@ -678,14 +679,28 @@ do
                 end
         end
 
-	function Raid:IncrementPlayerCount(name, raidNum)
-		local c = Raid:GetPlayerCount(name, raidNum)
-		Raid:SetPlayerCount(name, c + 1, raidNum)
-	end
+        function Raid:IncrementPlayerCount(name, raidNum)
+                if Raid:GetPlayerID(name, raidNum) == 0 then
+                        addon:PrintError(L.ErrCannotFindPlayer:format(name))
+                        return
+                end
+
+                local c = Raid:GetPlayerCount(name, raidNum)
+                Raid:SetPlayerCount(name, c + 1, raidNum)
+        end
 
         function Raid:DecrementPlayerCount(name, raidNum)
+                if Raid:GetPlayerID(name, raidNum) == 0 then
+                        addon:PrintError(L.ErrCannotFindPlayer:format(name))
+                        return
+                end
+
                 local c = Raid:GetPlayerCount(name, raidNum)
-                Raid:SetPlayerCount(name, math.max(0, c - 1), raidNum)
+                if c <= 0 then
+                        addon:PrintError(L.ErrPlayerCountBelowZero:format(name))
+                        return
+                end
+                Raid:SetPlayerCount(name, c - 1, raidNum)
         end
 
 	--------------------

--- a/!KRT/localization/localization.en.lua
+++ b/!KRT/localization/localization.en.lua
@@ -93,6 +93,7 @@ L.ErrScreenReminder        = "Please take a screenshot before trading, you never
 L.ErrItemStack             = "You have a stack of %s, you may want to split it first"
 L.ErrCannotFindItem        = "Cannot find item: %s"
 L.ErrCannotFindPlayer      = "Cannot find player: %s"
+L.ErrPlayerCountBelowZero  = "Cannot decrement player count below zero for %s"
 
 -- ==================== Configuration Frame ==================== --
 L.StrConfigSortAscending        = "Sort rolls ascending"


### PR DESCRIPTION
## Summary
- ensure SetPlayerCount errors on negative values
- guard Increment/Decrement against unknown players and negative counts
- localize new player count error message

## Testing
- `luacheck '!KRT/KRT.lua' '!KRT/localization/localization.en.lua'`


------
https://chatgpt.com/codex/tasks/task_e_6890c252da64832eb1569f4e644ca99e