### PR TITLE
Use utility wrappers for chat and item colors

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -147,14 +147,14 @@ local lootTypesText                     = {
 
 -- Roll Type Colored Display Text
 local lootTypesColored                  = {
-    GREEN_FONT_COLOR_CODE .. L.BtnMS .. FONT_COLOR_CODE_CLOSE,
-    LIGHTYELLOW_FONT_COLOR_CODE .. L.BtnOS .. FONT_COLOR_CODE_CLOSE,
-    "|cffa335ee" .. L.BtnSR .. FONT_COLOR_CODE_CLOSE,
-    NORMAL_FONT_COLOR_CODE .. L.BtnFree .. FONT_COLOR_CODE_CLOSE,
-    ORANGE_FONT_COLOR_CODE .. L.BtnBank .. FONT_COLOR_CODE_CLOSE,
-    RED_FONT_COLOR_CODE .. L.BtnDisenchant .. FONT_COLOR_CODE_CLOSE,
-    HIGHLIGHT_FONT_COLOR_CODE .. L.BtnHold .. FONT_COLOR_CODE_CLOSE,
-    GREEN_FONT_COLOR_CODE .. "DKP" .. FONT_COLOR_CODE_CLOSE,
+    Utils.WrapTextInColorCode(L.BtnMS, GREEN_FONT_COLOR_CODE:sub(3)),
+    Utils.WrapTextInColorCode(L.BtnOS, LIGHTYELLOW_FONT_COLOR_CODE:sub(3)),
+    Utils.WrapTextInColorCode(L.BtnSR, "ffa335ee"),
+    Utils.WrapTextInColorCode(L.BtnFree, NORMAL_FONT_COLOR_CODE:sub(3)),
+    Utils.WrapTextInColorCode(L.BtnBank, ORANGE_FONT_COLOR_CODE:sub(3)),
+    Utils.WrapTextInColorCode(L.BtnDisenchant, RED_FONT_COLOR_CODE:sub(3)),
+    Utils.WrapTextInColorCode(L.BtnHold, HIGHLIGHT_FONT_COLOR_CODE:sub(3)),
+    Utils.WrapTextInColorCode("DKP", GREEN_FONT_COLOR_CODE:sub(3)),
 }
 
 -- Item Quality Colors
@@ -1013,15 +1013,15 @@ do
     local output          = "%s: %s"
     local chatPrefix      = "Kader Raid Tools"
     local chatPrefixShort = "KRT"
-    local prefixHex       = Compat and Compat.RGBToHex(245/255, 140/255, 186/255)
+    local prefixHex       = Utils.RGBToHex(245/255, 140/255, 186/255)
 
     --
     -- Prepares the final output string with a prefix.
     --
     local function PreparePrint(text, prefix)
         prefix = prefix or chatPrefixShort
-        if prefixHex and Compat and Compat.WrapTextInColorCode then
-            prefix = Compat.WrapTextInColorCode(prefix, prefixHex)
+        if prefixHex then
+            prefix = Utils.WrapTextInColorCode(prefix, prefixHex)
         end
         return format(output, prefix, tostring(text))
     end
@@ -1753,7 +1753,7 @@ do
             if frameName == nil then return end
 
             local currentItemLink = _G[frameName .. "Name"]
-            currentItemLink:SetText("|c" .. i.itemColor .. i.itemName .. "|r")
+            currentItemLink:SetText(Utils.WrapTextInColorCode(i.itemName, i.itemColor))
 
             local currentItemBtn = _G[frameName .. "ItemBtn"]
             currentItemBtn:SetNormalTexture(i.itemTexture)
@@ -5278,7 +5278,7 @@ do
                 if not ROW_H then ROW_H = (row and row:GetHeight()) or 20 end
                 local ui = CacheParts(row, btn, parts)
 
-                ui.Name:SetText("|c" .. itemColors[v.itemRarity + 1] .. v.itemName .. "|r")
+                ui.Name:SetText(Utils.WrapTextInColorCode(v.itemName, itemColors[v.itemRarity + 1]))
                 ui.Source:SetText(addon.Logger.Boss:GetName(v.bossNum, addon.Logger.selectedRaid))
 
                 local r, g, b = addon:GetClassColor(addon:GetPlayerClass(v.looter))

--- a/!KRT/modules/Utils.lua
+++ b/!KRT/modules/Utils.lua
@@ -114,15 +114,36 @@ end
 
 -- Uppercase first:
 _G.string.ucfirst = function(str)
-	str = lower(str)
-	return gsub(str, "%a", upper, 1)
+        str = lower(str)
+        return gsub(str, "%a", upper, 1)
+end
+
+-- ============================================================================
+-- Color utilities
+-- ============================================================================
+
+function Utils.RGBToHex(r, g, b)
+        if r and g and b and r <= 1 and g <= 1 and b <= 1 then
+                r, g, b = r * 255, g * 255, b * 255
+        end
+        if Compat and Compat.RGBToHex then
+                return Compat.RGBToHex(r, g, b)
+        end
+        return format("%02x%02x%02x", r, g, b)
+end
+
+function Utils.WrapTextInColorCode(text, colorHexString)
+        if Compat and Compat.WrapTextInColorCode then
+                return Compat.WrapTextInColorCode(text, colorHexString)
+        end
+        return ("|c%s%s|r"):format(colorHexString, text)
 end
 
 -- Determines if a given string is a number
 function Utils.isNumber(str)
-	local valid = false
-	if str then
-		valid = find(str, "^(%d+%.?%d*)$")
+        local valid = false
+        if str then
+                valid = find(str, "^(%d+%.?%d*)$")
 	end
 	return valid
 end


### PR DESCRIPTION
## Summary
- add RGBToHex and WrapTextInColorCode helpers to Utils
- use Utils color wrappers throughout KRT.lua instead of manual color codes

## Testing
- `luac -p '!KRT/modules/Utils.lua'`
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68b89139fb8c832ea5b647a35171d99c