### PR TITLE
refactor: delegate helpers to Utils

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -269,7 +269,6 @@ do
     -- Register initial events and scripts
     addon:RegisterEvents("ADDON_LOADED")
     mainFrame:SetScript("OnEvent", HandleEvent)
-    mainFrame:SetScript("OnUpdate", Utils.run)
 end
 
 ---============================================================================
@@ -682,15 +681,8 @@ do
     --
     -- Returns the RGB color values for a given class name.
     --
-    do
-        function addon:GetClassColor(name)
-            name = (name == "DEATH KNIGHT") and "DEATHKNIGHT" or name
-            local c = Compat and Compat.GetClassColorObj(name)
-            if not c then
-                return 1, 1, 1
-            end
-            return c.r, c.g, c.b
-        end
+    function addon:GetClassColor(name)
+        return Utils.GetClassColor(name)
     end
 
     --


### PR DESCRIPTION
## Summary
- move generic helpers and timers to Utils
- add Compat-based helpers for colors and frame pools
- streamline class color API in main addon

## Testing
- `luac -p '!KRT/modules/Utils.lua'`
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68b8ce1eb268832e868c6bfb40813717