### PR TITLE
fix: preserve class colors and cancellable timers

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -102,6 +102,7 @@ local deformat                          = LibStub("LibDeformat-3.0")
 local LibCompat                         = LibStub("LibCompat-1.0")
 local AceBucket                         = LibStub("AceBucket-3.0")
 AceBucket:Embed(addon)
+addon.Compat                           = LibCompat
 
 -- Returns the used frame's name:
 function addon:GetFrameName()
@@ -352,8 +353,7 @@ do
 
 	-- Register some events and frame-related functions:
         addon:RegisterEvent("ADDON_LOADED")
-	mainFrame:SetScript("OnEvent", HandleEvent)
-	mainFrame:SetScript("OnUpdate", Utils.run)
+        mainFrame:SetScript("OnEvent", HandleEvent)
 end
 
 -- ==================== Raid Helpers ==================== --
@@ -669,18 +669,10 @@ do
 		return size
 	end
 
-	-- Return class color by name:
-	do
-		local colors = CUSTOM_CLASS_COLORS or RAID_CLASS_COLORS
-		function addon:GetClassColor(name)
-			name = (name == "DEATH KNIGHT") and "DEATHKNIGHT" or name
-			if not colors[name] then
-				return 1, 1, 1
-			end
-			local c = colors[name]
-			return c.r, c.g, c.b
-		end
-	end
+        -- Return class color by name:
+        function addon:GetClassColor(name)
+                return Utils.GetClassColor(name)
+        end
 
 	-- Checks if a raid is expired
 	function Raid:Expired(rID)

--- a/!KRT/modules/Utils.lua
+++ b/!KRT/modules/Utils.lua
@@ -11,6 +11,7 @@ local format, gsub = string.format, string.gsub
 local strsub, strlen = string.sub, string.len
 local lower, upper = string.lower, string.upper
 local select = select
+local unpack = unpack
 local GetLocale = GetLocale
 
 -- Shuffle a table:
@@ -115,7 +116,27 @@ end
 
 -- RBG to Hex:
 function Utils.rgb2hex(r, g, b)
-	return format("%02x%02x%02x", r * 255, g * 255, b * 255)
+        return format("%02x%02x%02x", r * 255, g * 255, b * 255)
+end
+
+-- Class color helpers
+do
+        local fallback = CUSTOM_CLASS_COLORS or RAID_CLASS_COLORS or {}
+        function Utils.GetClassColor(class)
+                class = class and upper(class)
+                local compat = addon.Compat
+                if compat and compat.GetClassColor then
+                        local r, g, b = compat:GetClassColor(class)
+                        if r and g and b then
+                                return r, g, b
+                        end
+                end
+                local c = fallback[class]
+                if c then
+                        return c.r, c.g, c.b
+                end
+                return 1, 1, 1
+        end
 end
 
 -- Enable/Disable Frame:
@@ -182,42 +203,38 @@ end
 -- Tasks Manager --
 -------------------
 do
-	-- Table of scheduled tasks:
-	local tasks = {}
+        -- Table of scheduled timers:
+        local scheduled = {}
 
-	-- Schedule a task:
-	function Utils.schedule(sec, func, ...)
-		local task = {}
-		task.time = time() + sec
-		task.func = func
-		for i = 1, select("#", ...) do
-			task[i] = select(i, ...)
-		end
-		tasks[#tasks+1] = task
-		tinsert(tasks, task)
-	end
+        -- Schedule a task and keep the timer handle so it can be cancelled later
+        function Utils.schedule(sec, func, ...)
+                if type(func) ~= "function" then return end
+                local handle
+                if addon.NewTimer then
+                        handle = addon:NewTimer(sec, func, ...)
+                elseif C_Timer and C_Timer.NewTimer then
+                        local args = { ... }
+                        handle = C_Timer.NewTimer(sec, function() func(unpack(args)) end)
+                elseif addon.After then
+                        local args = { ... }
+                        handle = addon.After(sec, function() func(unpack(args)) end)
+                end
+                scheduled[func] = handle
+                return handle
+        end
 
-	-- Unschedule a task:
-	function Utils.unschedule(func)
-		for i, v in pairs(tasks) do
-			if func == v.func then
-				tremove(tasks, i)
-				break
-			end
-		end
-	end
-
-	-- Run all scheduled tasks:
-	function Utils.run()
-		local now = time()
-		for i = 1, #tasks do
-			local task = tasks[i]
-			if task and type(task.func) == "function" and task.time <= now then
-				task.func(unpack(task))
-				tremove(tasks, i) -- Only once!
-			end
-		end
-	end
+        -- Unschedule a task using the stored handle
+        function Utils.unschedule(func)
+                local handle = scheduled[func]
+                if handle then
+                        if addon.CancelTimer then
+                                addon.CancelTimer(handle)
+                        elseif handle.Cancel then
+                                handle:Cancel()
+                        end
+                        scheduled[func] = nil
+                end
+        end
 end
 
 -- Periodic frame update:


### PR DESCRIPTION
## Summary
- fetch Compat dynamically in Utils to restore class colors
- track timer handles so scheduled callbacks can be cancelled
- expose LibCompat via addon and use Utils.GetClassColor in main addon

## Testing
- `luac -p '!KRT/modules/Utils.lua'`
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68b8d3af6d88832eaf391f9a75892ce8