### PR TITLE
perf(core): cache unit info helpers

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -210,6 +210,7 @@ local pairs, ipairs, type, select, next = pairs, ipairs, type, select, next
 local format, match, find, strlen       = string.format, string.match, string.find, string.len
 local strsub, gsub, lower, upper        = string.sub, string.gsub, string.lower, string.upper
 local tostring, tonumber, ucfirst       = tostring, tonumber, _G.string.ucfirst
+local UnitRace, UnitSex, GetRealmName   = UnitRace, UnitSex, GetRealmName
 
 local deformat                          = addon.Deformat
 local BossIDs                           = addon.BossIDs


### PR DESCRIPTION
## Summary
- cache `UnitRace`, `UnitSex` and `GetRealmName` calls in core

## Testing
- `luacheck '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6affbac832e8736167cdd34bcde