### PR TITLE
feat(debug): integrate debugger with LibLogger

### DIFF
--- a/!KRT/KRT.xml
+++ b/!KRT/KRT.xml
@@ -98,14 +98,12 @@
 				</Scripts>
 			</ScrollingMessageFrame>
 		</Frames>
-		<Scripts>
-			<OnDragStart>self:StartMoving()</OnDragStart>
-			<OnDragStop>self:StopMovingOrSizing()</OnDragStop>
-			<OnLoad>KRT.Debugger:OnLoad(self)</OnLoad>
-		</Scripts>
-		<Anchors>
-			<Anchor point="CENTER" />
-		</Anchors>
+                <Scripts>
+                        <OnLoad>KRT.Debugger:OnLoad(self)</OnLoad>
+                </Scripts>
+                <Anchors>
+                        <Anchor point="CENTER" />
+                </Anchors>
 		<!-- Title Text -->
 		<Layers>
 			<Layer level="ARTWORK">


### PR DESCRIPTION
## Summary
- route addon prints through new Debugger module
- add LibLogger-backed Debugger with buffered output and saved position
- clean debugger frame XML scripts

## Testing
- `luac -p '!KRT'/KRT.lua`
- `xmllint --noout '!KRT'/KRT.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d9720558832eabbcc90f503a2f3c