### PR TITLE
Validate LibStub presence before use

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -98,6 +98,8 @@ local pcall                             = pcall
 local format, match, find, strlen       = string.format, string.match, string.find, string.len
 local strsub, gsub, lower, upper        = string.sub, string.gsub, string.lower, string.upper
 local tostring, tonumber, ucfirst       = tostring, tonumber, _G.string.ucfirst
+local LibStub                          = _G.LibStub
+assert(LibStub, "LibStub library missing. Ensure Libs/LibStub.lua loads first.")
 local deformat                          = LibStub("LibDeformat-3.0")
 
 -- Returns the used frame's name:


### PR DESCRIPTION
## Summary
- Safely obtain `LibStub` from the global table and assert its existence before using it to load `LibDeformat-3.0`.
- Verify that `Libs/LibStub.lua` is listed before `KRT.lua` in the TOC and exists in the `Libs` folder.

## Testing
- `luacheck '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68bc0c0ff118832e9803ecd186e10f8e