### PR TITLE
fix(raid): ensure group count helper exists

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -224,7 +224,8 @@ local format, match, find, strlen       = string.format, string.match, string.fi
 local strsub, gsub, lower, upper        = string.sub, string.gsub, string.lower, string.upper
 local tostring, tonumber, ucfirst       = tostring, tonumber, _G.string.ucfirst
 local UnitRace, UnitSex, GetRealmName   = UnitRace, UnitSex, GetRealmName
-local GetGroupTypeAndCount = addon.GetGroupTypeAndCount
+local GetGroupTypeAndCount = assert(Compat and Compat.GetGroupTypeAndCount, "LibCompat-1.0 required")
+addon.GetGroupTypeAndCount = GetGroupTypeAndCount
 
 local deformat                          = addon.Deformat
 local BossIDs                           = addon.BossIDs


### PR DESCRIPTION
## Summary
- rely on `LibCompat-1.0`'s `GetGroupTypeAndCount` instead of local fallback

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68bd82268a04832e8449f9e4dffffead