### PR TITLE
refactor: adopt lower camel case for utils

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -177,14 +177,14 @@ local lootTypesText                     = {
 
 -- Roll Type Colored Display Text
 local lootTypesColored                  = {
-    Utils.WrapTextInColorCode(L.BtnMS, GREEN_FONT_COLOR_CODE:sub(3)),
-    Utils.WrapTextInColorCode(L.BtnOS, LIGHTYELLOW_FONT_COLOR_CODE:sub(3)),
-    Utils.WrapTextInColorCode(L.BtnSR, "ffa335ee"),
-    Utils.WrapTextInColorCode(L.BtnFree, NORMAL_FONT_COLOR_CODE:sub(3)),
-    Utils.WrapTextInColorCode(L.BtnBank, ORANGE_FONT_COLOR_CODE:sub(3)),
-    Utils.WrapTextInColorCode(L.BtnDisenchant, RED_FONT_COLOR_CODE:sub(3)),
-    Utils.WrapTextInColorCode(L.BtnHold, HIGHLIGHT_FONT_COLOR_CODE:sub(3)),
-    Utils.WrapTextInColorCode("DKP", GREEN_FONT_COLOR_CODE:sub(3)),
+    Utils.wrapTextInColorCode(L.BtnMS, GREEN_FONT_COLOR_CODE:sub(3)),
+    Utils.wrapTextInColorCode(L.BtnOS, LIGHTYELLOW_FONT_COLOR_CODE:sub(3)),
+    Utils.wrapTextInColorCode(L.BtnSR, "ffa335ee"),
+    Utils.wrapTextInColorCode(L.BtnFree, NORMAL_FONT_COLOR_CODE:sub(3)),
+    Utils.wrapTextInColorCode(L.BtnBank, ORANGE_FONT_COLOR_CODE:sub(3)),
+    Utils.wrapTextInColorCode(L.BtnDisenchant, RED_FONT_COLOR_CODE:sub(3)),
+    Utils.wrapTextInColorCode(L.BtnHold, HIGHLIGHT_FONT_COLOR_CODE:sub(3)),
+    Utils.wrapTextInColorCode("DKP", GREEN_FONT_COLOR_CODE:sub(3)),
 }
 
 -- Item Quality Colors
@@ -340,7 +340,7 @@ do
                         rank     = rank,
                         subgroup = subgroup,
                         class    = class or "UNKNOWN",
-                        join     = Utils.GetCurrentTime(),
+                        join     = Utils.getCurrentTime(),
                         leave    = nil,
                         count    = 0, -- <--- Inizializza count!
                     }
@@ -367,7 +367,7 @@ do
         -- Mark players who have left
         for name, v in pairs(playersByName) do
             if not v.seen and v.leave == nil then
-                v.leave = Utils.GetCurrentTime()
+                v.leave = Utils.getCurrentTime()
             end
             v.seen = nil
         end
@@ -387,7 +387,7 @@ do
 
         local realm = GetRealmName() or UNKNOWN
         KRT_Players[realm] = KRT_Players[realm] or {}
-        local currentTime = Utils.GetCurrentTime()
+        local currentTime = Utils.getCurrentTime()
 
         local raidInfo = {
             realm         = realm,
@@ -411,7 +411,7 @@ do
                     rank     = rank,
                     subgroup = subgroup,
                     class    = class or "UNKNOWN",
-                    join     = Utils.GetCurrentTime(),
+                    join     = Utils.getCurrentTime(),
                     leave    = nil,
                     count    = 0, -- Initialize loot count
                 }
@@ -431,7 +431,7 @@ do
 
         tinsert(KRT_Raids, raidInfo)
         KRT_CurrentRaid = #KRT_Raids
-        Utils.TriggerEvent("RaidCreate", KRT_CurrentRaid)
+        Utils.triggerEvent("RaidCreate", KRT_CurrentRaid)
         Utils.schedule(3, addon.UpdateRaidRoster)
     end
 
@@ -441,7 +441,7 @@ do
     function Raid:End()
         if not KRT_CurrentRaid then return end
         Utils.unschedule(addon.Raid.UpdateRaidRoster)
-        local currentTime = Utils.GetCurrentTime()
+        local currentTime = Utils.getCurrentTime()
         for _, v in pairs(KRT_Raids[KRT_CurrentRaid].players) do
             if not v.leave then v.leave = currentTime end
         end
@@ -548,7 +548,7 @@ do
                 end
             end
         end
-        local currentTime = Utils.GetCurrentTime()
+        local currentTime = Utils.getCurrentTime()
         local killInfo = {
             name       = bossName,
             difficulty = instanceDiff,
@@ -619,7 +619,7 @@ do
             rollType    = rollType,
             rollValue   = rollValue,
             bossNum     = KRT_LastBoss,
-            time        = Utils.GetCurrentTime(),
+            time        = Utils.getCurrentTime(),
         }
         tinsert(KRT_Raids[KRT_CurrentRaid].loot, lootInfo)
     end
@@ -709,7 +709,7 @@ do
     -- Returns the RGB color values for a given class name.
     --
     function addon:GetClassColor(name)
-        return Utils.GetClassColor(name)
+        return Utils.getClassColor(name)
     end
 
     --
@@ -721,7 +721,7 @@ do
             return true
         end
 
-        local currentTime = Utils.GetCurrentTime()
+        local currentTime = Utils.getCurrentTime()
         local startTime = KRT_Raids[rID].startTime
         local validDuration = (currentTime + KRT_NextReset) - startTime
 
@@ -1016,7 +1016,7 @@ do
     local output          = "%s: %s"
     local chatPrefix      = "Kader Raid Tools"
     local chatPrefixShort = "KRT"
-    local prefixHex       = Utils.RGBToHex(245/255, 140/255, 186/255)
+    local prefixHex       = Utils.rgbToHex(245/255, 140/255, 186/255)
 
     --
     -- Prepares the final output string with a prefix.
@@ -1024,7 +1024,7 @@ do
     local function PreparePrint(text, prefix)
         prefix = prefix or chatPrefixShort
         if prefixHex then
-            prefix = Utils.WrapTextInColorCode(prefix, prefixHex)
+            prefix = Utils.wrapTextInColorCode(prefix, prefixHex)
         end
         return format(output, prefix, tostring(text))
     end
@@ -1329,7 +1329,7 @@ do
                 itemRollTracker[itemId][name])
         end
 
-        Utils.TriggerEvent("AddRoll", name, roll)
+        Utils.triggerEvent("AddRoll", name, roll)
         SortRolls()
 
         -- Auto-select winner if none is manually selected
@@ -1501,7 +1501,7 @@ do
     -- Clears all roll-related state and UI elements.
     --
     function addon:ClearRolls(rec)
-        frameName = frameName or Utils.GetFrameName()
+        frameName = frameName or Utils.getFrameName()
         if not frameName then return end
         rollsTable, rerolled, itemRollTracker = {}, {}, {}
         playerRollTracker, rolled, warned, rollsCount = {}, false, false, 0
@@ -1582,7 +1582,7 @@ do
     -- Rebuilds the roll list UI and marks the top roller or selected winner.
     --
     function addon:FetchRolls()
-        local frameName = Utils.GetFrameName()
+        local frameName = Utils.getFrameName()
         addon:Debug("DEBUG", "FetchRolls called; frameName: %s", frameName)
         local scrollFrame = _G[frameName .. "ScrollFrame"]
         local scrollChild = _G[frameName .. "ScrollFrameScrollChild"]
@@ -1751,7 +1751,7 @@ do
         lootTable[lootCount].itemColor   = itemColors[itemRarity + 1]
         lootTable[lootCount].itemLink    = itemLink
         lootTable[lootCount].itemTexture = itemTexture
-        Utils.TriggerEvent("AddItem", itemLink)
+        Utils.triggerEvent("AddItem", itemLink)
     end
 
     --
@@ -1768,11 +1768,11 @@ do
     --
     function addon:SetItem(i)
         if i.itemName and i.itemLink and i.itemTexture and i.itemColor then
-            frameName = frameName or Utils.GetFrameName()
+            frameName = frameName or Utils.getFrameName()
             if frameName == nil then return end
 
             local currentItemLink = _G[frameName .. "Name"]
-            currentItemLink:SetText(Utils.WrapTextInColorCode(i.itemName, i.itemColor))
+            currentItemLink:SetText(Utils.wrapTextInColorCode(i.itemName, i.itemColor))
 
             local currentItemBtn = _G[frameName .. "ItemBtn"]
             currentItemBtn:SetNormalTexture(i.itemTexture)
@@ -1781,7 +1781,7 @@ do
                 currentItemBtn.tooltip_item = i.itemLink
                 self:SetTooltip(currentItemBtn, nil, "ANCHOR_CURSOR")
             end
-            Utils.TriggerEvent("SetItem", i.itemLink)
+            Utils.triggerEvent("SetItem", i.itemLink)
         end
     end
 
@@ -1801,7 +1801,7 @@ do
     function addon:ClearLoot()
         lootTable = twipe(lootTable)
         lootCount = 0
-        frameName = frameName or Utils.GetFrameName()
+        frameName = frameName or Utils.getFrameName()
         _G[frameName .. "Name"]:SetText(L.StrNoItemSelected)
         _G[frameName .. "ItemBtn"]:SetNormalTexture("Interface\\PaperDoll\\UI-Backpack-EmptySlot")
         if frameName == UIMaster:GetName() then
@@ -2682,7 +2682,7 @@ do
     end
 
     -- Register some callbacks:
-    Utils.RegisterCallback("SetItem", function(f, itemLink)
+    Utils.registerCallback("SetItem", function(f, itemLink)
         local oldItem = GetItemLink()
         if oldItem ~= itemLink then
             announced = false
@@ -2706,7 +2706,7 @@ do
         scrollChild = scrollChild or _G["KRTLootCounterFrameScrollFrameScrollChild"]
         if countsFrame and not countsFrame._krtCounterHook then
             countsFrame:SetScript("OnUpdate", function()
-                if needsUpdate and Utils.Throttle("LootCounter", 0.1) then
+                if needsUpdate and Utils.throttleKey("LootCounter", 0.1) then
                     needsUpdate = false
                     addon:UpdateCountsFrame()
                 end
@@ -3560,7 +3560,7 @@ do
             _G[frameName .. "countdownDurationText"]:SetText(value)
         end
         name = strsub(name, strlen(frameName) + 1)
-        Utils.TriggerEvent("Config" .. name, value)
+        Utils.triggerEvent("Config" .. name, value)
         KRT_Options[name] = value
     end
 
@@ -3993,7 +3993,7 @@ do
         end
     end
 
-    Utils.RegisterCallback("RaidLeave", function(e, name)
+    Utils.registerCallback("RaidLeave", function(e, name)
         Changes:Delete(name)
         CancelChanges()
     end)
@@ -4480,7 +4480,7 @@ do
     local running
 
     local function Send(msg)
-        if U.Throttle("lfm_msg", _G.KRT_Options.chatThrottle or 2.0) then
+        if U.throttleKey("lfm_msg", _G.KRT_Options.chatThrottle or 2.0) then
             SendChatMessage(msg, IsInRaid() and "RAID" or "GUILD")
         end
     end
@@ -4491,7 +4491,7 @@ do
         local raidName = GetRealZoneText() or "Raid"
         local text = msg:gsub("{raid}", raidName):gsub("{roles}", "T/H/D"):gsub("{time}", date("%H:%M"))
         Send(text)
-        U.Schedule(_G.KRT_Options.lfmPeriod or 45, Tick)
+        U.scheduleDelay(_G.KRT_Options.lfmPeriod or 45, Tick)
     end
 
     function S:Init() end
@@ -4587,7 +4587,7 @@ do
     -- toggle campo selezionato + evento
     local function selectAndTrigger(ns, field, id, event)
         ns[field] = (id ~= ns[field]) and id or nil
-        Utils.TriggerEvent(event, id)
+        Utils.triggerEvent(event, id)
         return ns[field]
     end
 
@@ -4804,7 +4804,7 @@ do
     -- selettori (toggle + evento)
     local function sel(field, id, ev)
         addon.History[field] = (id ~= addon.History[field]) and id or nil
-        Utils.TriggerEvent(ev, id)
+        Utils.triggerEvent(ev, id)
     end
     function History:SelectRaid(btn) if btn then sel("selectedRaid", btn:GetID(), "HistorySelectRaid") end end
 
@@ -4898,7 +4898,7 @@ do
         }
     end
 
-    Utils.RegisterCallback("HistorySelectRaid", function()
+    Utils.registerCallback("HistorySelectRaid", function()
         addon.History.selectedBoss, addon.History.selectedPlayer, addon.History.selectedItem = nil, nil, nil
     end)
 end
@@ -4931,7 +4931,7 @@ do
             local count = #KRT_Raids
             for i = 1, count do
                 local r = KRT_Raids[i]
-                local it = out[i] or Utils.AcquireTable()
+                local it = out[i] or Utils.acquireTable()
                 it.id      = i
                 it.zone    = r.zone
                 it.size    = r.size
@@ -4940,7 +4940,7 @@ do
                 out[i] = it
             end
             for i = count + 1, #out do
-                Utils.ReleaseTable(out[i])
+                Utils.releaseTable(out[i])
                 out[i] = nil
             end
         end,
@@ -5021,7 +5021,7 @@ do
         (controller._makeConfirmPopup)("KRTHISTORY_DELETE_RAID", L.StrConfirmDeleteRaid, DeleteRaid)
     end
 
-    Utils.RegisterCallback("RaidCreate", function(_, num)
+    Utils.registerCallback("RaidCreate", function(_, num)
         addon.History.selectedRaid = tonumber(num)
         controller:Dirty()
     end)
@@ -5048,7 +5048,7 @@ do
             local src = addon.Raid:GetBosses(addon.History.selectedRaid) or {}
             for i = 1, #src do
                 local b = src[i]
-                local it = out[i] or Utils.AcquireTable()
+                local it = out[i] or Utils.acquireTable()
                 it.id      = b.id
                 it.name    = b.name
                 it.time    = b.time
@@ -5057,7 +5057,7 @@ do
                 out[i] = it
             end
             for i = #src + 1, #out do
-                Utils.ReleaseTable(out[i])
+                Utils.releaseTable(out[i])
                 out[i] = nil
             end
             table.sort(out, function(a, b) return a.id > b.id end)
@@ -5132,7 +5132,7 @@ do
         return name
     end
 
-    Utils.RegisterCallback("HistorySelectRaid", function() controller:Dirty() end)
+    Utils.registerCallback("HistorySelectRaid", function() controller:Dirty() end)
 end
 
 -- ============================================================================
@@ -5150,20 +5150,20 @@ do
 
         getData        = function(out)
             if not addon.History.selectedBoss then
-                for i = #out, 1, -1 do Utils.ReleaseTable(out[i]); out[i] = nil end
+                for i = #out, 1, -1 do Utils.releaseTable(out[i]); out[i] = nil end
                 return
             end
             local src = addon.Raid:GetPlayers(addon.History.selectedRaid, addon.History.selectedBoss) or {}
             for i = 1, #src do
                 local p = src[i]
-                local it = out[i] or Utils.AcquireTable()
+                local it = out[i] or Utils.acquireTable()
                 it.id    = p.id
                 it.name  = p.name
                 it.class = p.class
                 out[i] = it
             end
             for i = #src + 1, #out do
-                Utils.ReleaseTable(out[i])
+                Utils.releaseTable(out[i])
                 out[i] = nil
             end
         end,
@@ -5221,8 +5221,8 @@ do
     end
 
     local function Reset() controller:Dirty() end
-    Utils.RegisterCallback("HistorySelectRaid", Reset)
-    Utils.RegisterCallback("HistorySelectBoss", Reset)
+    Utils.registerCallback("HistorySelectRaid", Reset)
+    Utils.registerCallback("HistorySelectBoss", Reset)
 end
 
 -- ============================================================================
@@ -5249,7 +5249,7 @@ do
             local src = addon.Raid:GetPlayers(addon.History.selectedRaid) or {}
             for i = 1, #src do
                 local p = src[i]
-                local it = out[i] or Utils.AcquireTable()
+                local it = out[i] or Utils.acquireTable()
                 it.id       = p.id
                 it.name     = p.name
                 it.class    = p.class
@@ -5260,7 +5260,7 @@ do
                 out[i] = it
             end
             for i = #src + 1, #out do
-                Utils.ReleaseTable(out[i])
+                Utils.releaseTable(out[i])
                 out[i] = nil
             end
         end,
@@ -5317,7 +5317,7 @@ do
         (controller._makeConfirmPopup)("KRTHISTORY_DELETE_RAIDATTENDEE", L.StrConfirmDeleteAttendee, DeleteAttendee)
     end
 
-    Utils.RegisterCallback("HistorySelectRaid", function() controller:Dirty() end)
+    Utils.registerCallback("HistorySelectRaid", function() controller:Dirty() end)
 end
 
 -- ============================================================================
@@ -5363,7 +5363,7 @@ do
 
             for i = 1, #data do
                 local v = data[i]
-                local it = out[i] or Utils.AcquireTable()
+                local it = out[i] or Utils.acquireTable()
                 it.id          = v.id
                 it.itemId      = v.itemId
                 it.itemName    = v.itemName
@@ -5379,7 +5379,7 @@ do
                 out[i] = it
             end
             for i = #data + 1, #out do
-                Utils.ReleaseTable(out[i])
+                Utils.releaseTable(out[i])
                 out[i] = nil
             end
         end,
@@ -5394,7 +5394,7 @@ do
                 if not ROW_H then ROW_H = (row and row:GetHeight()) or 20 end
                 local ui = CacheParts(row, btn, parts)
 
-                ui.Name:SetText(Utils.WrapTextInColorCode(v.itemName, itemColors[v.itemRarity + 1]))
+                ui.Name:SetText(Utils.wrapTextInColorCode(v.itemName, itemColors[v.itemRarity + 1]))
                 ui.Source:SetText(addon.History.Boss:GetName(v.bossNum, addon.History.selectedRaid))
 
                 local r, g, b = addon:GetClassColor(addon:GetPlayerClass(v.looter))
@@ -5466,9 +5466,9 @@ do
     end
 
     local function Reset() controller:Dirty() end
-    Utils.RegisterCallback("HistorySelectRaid", Reset)
-    Utils.RegisterCallback("HistorySelectBoss", Reset)
-    Utils.RegisterCallback("HistorySelectPlayer", Reset)
+    Utils.registerCallback("HistorySelectRaid", Reset)
+    Utils.registerCallback("HistorySelectBoss", Reset)
+    Utils.registerCallback("HistorySelectPlayer", Reset)
 end
 
 -- ============================================================================
@@ -5542,7 +5542,7 @@ do
         end
 
         self:Hide()
-        Utils.TriggerEvent("HistorySelectRaid")
+        Utils.triggerEvent("HistorySelectRaid")
     end
 
     function Box:CancelAddEdit()
@@ -5927,7 +5927,7 @@ function addon:COMBAT_LOG_EVENT_UNFILTERED(...)
     local _, event, _, _, _, destGUID, destName = ...
     if not KRT_CurrentRaid then return end
     if event == "UNIT_DIED" then
-        local npcID = Utils.GetNPCID(destGUID)
+        local npcID = Utils.getNpcId(destGUID)
         if addon.BossIDs.BossIDs[npcID] then
             self.Raid:AddBoss(destName)
         end

--- a/!KRT/Localization/localization.en.lua
+++ b/!KRT/Localization/localization.en.lua
@@ -15,7 +15,7 @@ addon.L                           = setmetatable(addon.L, {
 local L                           = addon.L -- Make a local reference for convenience within this file
 
 -- ==================== Callbacks ==================== --
-L.StrCbErrUsage                   = "Usage: KRT:RegisterCallback(event, callbacks)"
+L.StrCbErrUsage                   = "Usage: KRT:registerCallback(event, callbacks)"
 L.StrCbErrExec                    = "Error while executing callback %s for event %s: %s"
 
 -- ==================== General Buttons ==================== --

--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -28,7 +28,7 @@ local CreateFrame = CreateFrame
 -- Table pool (no table.new in 3.3.5a)
 local TPOOL = setmetatable({}, { __mode = "k" })
 
-function Utils.AcquireTable()
+function Utils.acquireTable()
         for t in pairs(TPOOL) do
                 TPOOL[t] = nil
                 twipe(t)
@@ -37,7 +37,7 @@ function Utils.AcquireTable()
         return {}
 end
 
-function Utils.ReleaseTable(t)
+function Utils.releaseTable(t)
         if t then
                 twipe(t)
                 TPOOL[t] = true
@@ -46,7 +46,7 @@ end
 
 -- Lightweight throttle (keyed)
 local last = {}
-function Utils.Throttle(key, sec)
+function Utils.throttleKey(key, sec)
         local now = GetTime()
         sec = sec or 1
         if not last[key] or (now - last[key]) >= sec then
@@ -71,13 +71,13 @@ Driver:SetScript("OnUpdate", function(_, _)
         end
 end)
 
-function Utils.Schedule(delay, func)
+function Utils.scheduleDelay(delay, func)
         if type(func) ~= "function" then return end
         Queue[#Queue + 1] = { t = GetTime() + (delay or 0), f = func }
 end
 
 -- Color helper (common usage)
-function Utils.ColorText(text, r, g, b)
+function Utils.colorText(text, r, g, b)
         return ("|cff%02x%02x%02x%s|r"):format((r or 1) * 255, (g or 0.82) * 255, (b or 0) * 255, text)
 end
 
@@ -87,7 +87,7 @@ end
 
 local callbacks = {}
 
-function Utils.RegisterCallback(e, func)
+function Utils.registerCallback(e, func)
         if not e or type(func) ~= "function" then
                 error(L.StrCbErrUsage)
         end
@@ -96,7 +96,7 @@ function Utils.RegisterCallback(e, func)
         return #callbacks
 end
 
-function Utils.TriggerEvent(e, ...)
+function Utils.triggerEvent(e, ...)
         if not callbacks[e] then return end
         for i, v in ipairs(callbacks[e]) do
                 local ok, err = pcall(v, e, ...)
@@ -110,7 +110,7 @@ end
 -- Frame helpers
 -- ============================================================================
 
-function Utils.GetFrameName()
+function Utils.getFrameName()
         local name
         if addon.UIMaster ~= nil then
                 name = addon.UIMaster:GetName()
@@ -189,7 +189,7 @@ end
 -- Color utilities
 -- ============================================================================
 
-function Utils.RGBToHex(r, g, b)
+function Utils.rgbToHex(r, g, b)
         if r and g and b and r <= 1 and g <= 1 and b <= 1 then
                 r, g, b = r * 255, g * 255, b * 255
         end
@@ -199,14 +199,14 @@ function Utils.RGBToHex(r, g, b)
         return format("%02x%02x%02x", r, g, b)
 end
 
-function Utils.WrapTextInColorCode(text, colorHexString)
+function Utils.wrapTextInColorCode(text, colorHexString)
         if Compat and Compat.WrapTextInColorCode then
                 return Compat.WrapTextInColorCode(text, colorHexString)
         end
         return ("|c%s%s|r"):format(colorHexString, text)
 end
 
-function Utils.GetClassColor(name)
+function Utils.getClassColor(name)
         name = (name == "DEATH KNIGHT") and "DEATHKNIGHT" or name
         local c = Compat and Compat.GetClassColorObj and Compat.GetClassColorObj(name)
         if not c then
@@ -262,7 +262,7 @@ function Utils.showHide(frame, cond)
         end
 end
 
-function Utils.CreatePool(frameType, parent, template, resetter)
+function Utils.createPool(frameType, parent, template, resetter)
         if Compat and Compat.CreateFramePool then
                 return Compat.CreateFramePool(frameType, parent, template, resetter)
         end
@@ -475,13 +475,13 @@ function Utils.getSecondsAsString(t)
 end
 
 -- Determines if the player is in a raid instance
-function Utils.IsRaidInstance()
+function Utils.isRaidInstance()
 	local inInstance, instanceType = IsInInstance()
 	return ((inInstance) and (instanceType == "raid"))
 end
 
 -- Returns the raid difficulty:
-function Utils.GetDifficulty()
+function Utils.getDifficulty()
 	local difficulty = nil
 	local inInstance, instanceType = IsInInstance()
 	if inInstance and instanceType == "raid" then
@@ -491,7 +491,7 @@ function Utils.GetDifficulty()
 end
 
 -- Returns the NPCID or nil:
-function Utils.GetNPCID(GUID)
+function Utils.getNpcId(GUID)
 	local first3 = tonumber("0x" .. strsub(GUID, 3, 5))
 	local unitType = bit.band(first3, 0x007)
 	if ((unitType == 0x003) or (unitType == 0x005)) then
@@ -501,7 +501,7 @@ function Utils.GetNPCID(GUID)
 end
 
 -- Returns the current time:
-function Utils.GetCurrentTime(server)
+function Utils.getCurrentTime(server)
 	server = server or true
 	local t = time()
 	if server == true then
@@ -513,7 +513,7 @@ function Utils.GetCurrentTime(server)
 end
 
 -- Returns the server offset:
-function Utils.GetServerOffset()
+function Utils.getServerOffset()
 	local sH, sM = GetGameTime()
 	local lH, lM = tonumber(date("%H")), tonumber(date("%M"))
         local sT = sH + sM / 60


### PR DESCRIPTION
## Summary
- rename public helpers in `Utils` to lowerCamelCase (`acquireTable`, `throttleKey`, `wrapTextInColorCode`, etc.)
- adjust all call sites and localization to new helper names

## Testing
- `luac -p '!KRT/Modules/Utils.lua'`
- `luac -p '!KRT/KRT.lua'`
- `luac -p '!KRT/Localization/localization.en.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68bdc5760330832ebd5f96fea23fd922