### PR TITLE
fix(rolls): correct reserved roll type casing

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1340,7 +1340,7 @@ do
         -- Auto-select winner if none is manually selected
         if not selectedPlayer then
             local resolvedItemId = itemId or addon:GetCurrentRollItemID()
-            if currentRollType == rollTypes.reserved then
+            if currentRollType == rollTypes.RESERVED then
                 local topRoll = -1
                 for _, entry in ipairs(rollsTable) do
                     if addon:IsReserved(resolvedItemId, entry.name) and entry.roll > topRoll then
@@ -1368,7 +1368,7 @@ do
         local name = UnitName("player")
         local allowed = 1
 
-        if currentRollType == rollTypes.reserved then
+        if currentRollType == rollTypes.RESERVED then
             allowed = addon.Reserves:GetReserveCountForItem(itemId, name)
         end
 
@@ -1426,7 +1426,7 @@ do
             end
 
             local allowed = 1
-            if currentRollType == rollTypes.reserved then
+            if currentRollType == rollTypes.RESERVED then
                 local playerReserves = addon.Reserves:GetReserveCountForItem(itemId, player)
                 allowed = playerReserves > 0 and playerReserves or 1
             end
@@ -1481,7 +1481,7 @@ do
 
         itemRollTracker[itemId] = itemRollTracker[itemId] or {}
         local used = itemRollTracker[itemId][name] or 0
-        local allowed = (currentRollType == rollTypes.reserved and addon.Reserves:GetReserveCountForItem(itemId, name) > 0)
+        local allowed = (currentRollType == rollTypes.RESERVED and addon.Reserves:GetReserveCountForItem(itemId, name) > 0)
             and addon.Reserves:GetReserveCountForItem(itemId, name) or 1
         local result = used >= allowed
         addon:Debug("DEBUG", "DidRoll: name=%s, itemId=%d, used=%d, allowed=%d, result=%s", name, itemId, used, allowed,
@@ -1546,7 +1546,7 @@ do
     function addon:IsValidRoll(itemId, name)
         itemRollTracker[itemId] = itemRollTracker[itemId] or {}
         local used = itemRollTracker[itemId][name] or 0
-        local allowed = (currentRollType == rollTypes.reserved)
+        local allowed = (currentRollType == rollTypes.RESERVED)
             and addon.Reserves:GetReserveCountForItem(itemId, name)
             or 1
         local result = used < allowed
@@ -1595,7 +1595,7 @@ do
         scrollChild:SetWidth(scrollFrame:GetWidth())
 
         local itemId = self:GetCurrentRollItemID()
-        local isSR = currentRollType == rollTypes.reserved
+        local isSR = currentRollType == rollTypes.RESERVED
         addon:Debug("DEBUG", "Current itemId: %s, SR mode: %s", tostring(itemId), tostring(isSR))
 
         local starTarget = selectedPlayer
@@ -2010,7 +2010,7 @@ do
             local itemID = tonumber(string.match(itemLink or "", "item:(%d+)"))
             local message = ""
 
-            if rollType == rollTypes.reserved and addon.Reserves and addon.Reserves.FormatReservedPlayersLine then
+            if rollType == rollTypes.RESERVED and addon.Reserves and addon.Reserves.FormatReservedPlayersLine then
                 local srList = addon.Reserves:FormatReservedPlayersLine(itemID)
                 local suff = addon.options.sortAscending and "Low" or "High"
                 message = itemCount > 1


### PR DESCRIPTION
## Summary
- use `rollTypes.RESERVED` for soft-reserve roll checks to match enum casing

## Testing
- `lua - <<'EOF'
-- [setup stubbed WoW API + addon]
... (omitted for brevity)
used 0  true
used 1  true
used 2  false
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68bea462f650832e988d6f1ce1e40697