### PR TITLE
ref(core): remove redundant module aliases

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -5519,7 +5519,7 @@ end
 -- ============================================================================
 do
     addon.History.Loot = addon.History.Loot or {}
-    local Loot = addon.History.Loot
+    local module = addon.History.Loot
 
     local raidLoot = {} -- cache per tooltip OnEnter (lista completa del raid)
 


### PR DESCRIPTION
## Summary
- drop redundant second aliases in KRT.lua modules so each keeps a single `module` alias

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68bec62a80b0832e9869dd30272d9080