### PR TITLE
fix(core): alias Loot module correctly

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -5519,7 +5519,7 @@ end
 -- ============================================================================
 do
     addon.History.Loot = addon.History.Loot or {}
-    local Loot = addon.History.Loot
+    local module = addon.History.Loot
 
     local raidLoot = {} -- cache per tooltip OnEnter (lista completa del raid)
 


### PR DESCRIPTION
## Summary
- fix Loot history methods indexing nil module by aliasing the Loot table to `module`

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68bed1a16978832ebd4e2877a6746904