### PR TITLE
fix(core): use compat IsInRaid

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -250,7 +250,8 @@ local format, match, find, strlen       = string.format, string.match, string.fi
 local strsub, gsub, lower, upper        = string.sub, string.gsub, string.lower, string.upper
 local tostring, tonumber, ucfirst       = tostring, tonumber, _G.string.ucfirst
 local UnitRace, UnitSex, GetRealmName   = UnitRace, UnitSex, GetRealmName
-local IsInRaid, GetNumRaidMembers, GetNumPartyMembers = IsInRaid, GetNumRaidMembers, GetNumPartyMembers
+local IsInRaid, GetNumRaidMembers, GetNumPartyMembers =
+    addon.IsInRaid or IsInRaid, GetNumRaidMembers, GetNumPartyMembers
 
 ---============================================================================
 -- Event System


### PR DESCRIPTION
## Summary
- avoid nil IsInRaid by using embedded LibCompat helper

## Testing
- `luacheck '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68bf0d0d4864832ea86d383d272df37a