### PR TITLE
ref(utils): use Utils.Table helpers for pooling

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -5148,7 +5148,7 @@ do
             local count = #KRT_Raids
             for i = 1, count do
                 local r = KRT_Raids[i]
-                local it = out[i] or Utils.acquireTable()
+                local it = out[i] or Utils.Table.get("history-raids")
                 it.id      = i
                 it.zone    = r.zone
                 it.size    = r.size
@@ -5157,7 +5157,7 @@ do
                 out[i] = it
             end
             for i = count + 1, #out do
-                Utils.releaseTable(out[i])
+                Utils.Table.free(out[i])
                 out[i] = nil
             end
         end,
@@ -5266,7 +5266,7 @@ do
             local src = addon.Raid:GetBosses(addon.History.selectedRaid) or {}
             for i = 1, #src do
                 local b = src[i]
-                local it = out[i] or Utils.acquireTable()
+                local it = out[i] or Utils.Table.get("history-bosses")
                 it.id      = b.id
                 it.name    = b.name
                 it.time    = b.time
@@ -5275,7 +5275,7 @@ do
                 out[i] = it
             end
             for i = #src + 1, #out do
-                Utils.releaseTable(out[i])
+                Utils.Table.free(out[i])
                 out[i] = nil
             end
             table.sort(out, function(a, b) return a.id > b.id end)
@@ -5368,20 +5368,20 @@ do
 
         getData        = function(out)
             if not addon.History.selectedBoss then
-                for i = #out, 1, -1 do Utils.releaseTable(out[i]); out[i] = nil end
+                for i = #out, 1, -1 do Utils.Table.free(out[i]); out[i] = nil end
                 return
             end
             local src = addon.Raid:GetPlayers(addon.History.selectedRaid, addon.History.selectedBoss) or {}
             for i = 1, #src do
                 local p = src[i]
-                local it = out[i] or Utils.acquireTable()
+                local it = out[i] or Utils.Table.get("history-boss-attendees")
                 it.id    = p.id
                 it.name  = p.name
                 it.class = p.class
                 out[i] = it
             end
             for i = #src + 1, #out do
-                Utils.releaseTable(out[i])
+                Utils.Table.free(out[i])
                 out[i] = nil
             end
         end,
@@ -5486,7 +5486,7 @@ do
             local src = addon.Raid:GetPlayers(addon.History.selectedRaid) or {}
             for i = 1, #src do
                 local p = src[i]
-                local it = out[i] or Utils.acquireTable()
+                local it = out[i] or Utils.Table.get("history-raid-attendees")
                 it.id       = p.id
                 it.name     = p.name
                 it.class    = p.class
@@ -5497,7 +5497,7 @@ do
                 out[i] = it
             end
             for i = #src + 1, #out do
-                Utils.releaseTable(out[i])
+                Utils.Table.free(out[i])
                 out[i] = nil
             end
         end,
@@ -5604,7 +5604,7 @@ do
 
             for i = 1, #data do
                 local v = data[i]
-                local it = out[i] or Utils.acquireTable()
+                local it = out[i] or Utils.Table.get("history-loot")
                 it.id          = v.id
                 it.itemId      = v.itemId
                 it.itemName    = v.itemName
@@ -5620,7 +5620,7 @@ do
                 out[i] = it
             end
             for i = #data + 1, #out do
-                Utils.releaseTable(out[i])
+                Utils.Table.free(out[i])
                 out[i] = nil
             end
         end,

--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -36,35 +36,15 @@ local function round(number, significance)
 	return floor((number / (significance or 1)) + 0.5) * (significance or 1)
 end
 local setmetatable, getmetatable = setmetatable, getmetatable
-local tinsert, tremove, twipe = table.insert, table.remove, table.wipe
+local tinsert, tremove = table.insert, table.remove
 local find, match = string.find, string.match
 local format, gsub = string.format, string.gsub
 local strsub, strlen = string.sub, string.len
 local lower, upper = string.lower, string.upper
 local select, unpack = select, unpack
 local GetLocale = GetLocale
-
--- Lightweight pooling
 local GetTime = GetTime
 
--- Table pool (no table.new in 3.3.5a)
-local TPOOL = setmetatable({}, { __mode = "k" })
-
-function Utils.acquireTable()
-        for t in pairs(TPOOL) do
-                TPOOL[t] = nil
-                twipe(t)
-                return t
-        end
-        return {}
-end
-
-function Utils.releaseTable(t)
-        if t then
-                twipe(t)
-                TPOOL[t] = true
-        end
-end
 -- Lightweight throttle (keyed)
 local last = {}
 function Utils.throttleKey(key, sec)


### PR DESCRIPTION
## Summary
- drop custom TPOOL and acquire/release helpers in favor of Utils.Table
- switch history builders to Utils.Table.get/free with descriptive tags

## Testing
- `luac -p '!KRT/Modules/Utils.lua'`
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c013de66c0832eb2b22fcf784be5c1