### PR TITLE
ref(core): use UnitIterator for dropdown roster prep

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -2432,8 +2432,9 @@ do
             dropDownData[i] = twipe(dropDownData[i])
         end
         dropDownGroupData = twipe(dropDownGroupData)
-        for p = 1, GetRealNumRaidMembers() do
-            local name, _, subgroup = GetRaidRosterInfo(p)
+        for unit in UnitIterator() do
+            local name = UnitName(unit)
+            local subgroup = select(2, GetRaidRosterInfo(UnitInRaid(unit)))
             if name then
                 dropDownData[subgroup][name] = name
                 dropDownGroupData[subgroup] = true


### PR DESCRIPTION
## Summary
- simplify dropdown roster population using UnitIterator

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c056b9d614832e99bf9c4731db62ad