### PR TITLE
fix(master): limit loot candidate scan to raid size

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -2670,7 +2670,7 @@ do
             return false
         end
 
-        for p = 1, 40 do
+        for p = 1, addon.Raid:GetNumRaid() do
             if GetMasterLootCandidate(p) == playerName then
                 GiveMasterLoot(itemIndex, p)
                 local output, whisper


### PR DESCRIPTION
## Summary
- limit master loot assignment to current raid size

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c057c29b70832e9b83cd503c075106