### PR TITLE
ref(raid): use LibCompat GUID helpers

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -58,7 +58,6 @@ local UnitIterator  = addon.UnitIterator
 local After         = addon.After
 local NewTicker     = addon.NewTicker
 local CancelTimer   = addon.CancelTimer
-local GetCreatureId = addon.GetCreatureId
 local tLength       = addon.tLength
 
 function addon:Debug(level, fmt, ...)
@@ -6271,12 +6270,14 @@ end
 -- COMBAT_LOG_EVENT_UNFILTERED: Logs a boss kill when a boss unit dies.
 --
 function addon:COMBAT_LOG_EVENT_UNFILTERED(...)
-    local _, event, _, _, _, destGUID, destName = ...
+    local _, event, _, _, _, destGUID = ...
     if not KRT_CurrentRaid then return end
     if event == "UNIT_DIED" then
-        local npcID = Utils.getNpcId(destGUID)
-        if addon.BossIDs.BossIDs[npcID] then
-            self.Raid:AddBoss(destName)
+        if addon.GetUnitIdFromGUID(destGUID, "player") then return end
+        local npcId = addon.GetCreatureId(destGUID)
+        local boss = addon.BossIDs:GetBossName(npcId)
+        if boss then
+            self.Raid:AddBoss(boss)
         end
     end
 end

--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -10,9 +10,6 @@ if Compat and Compat.Embed then
        Compat:Embed(Utils) -- Utils.After, Utils.UnitIterator, Utils.Table, etc.
 end
 
--- Back-compat/lightweight aliases
-Utils.getNpcId = Utils.GetCreatureId -- use LibCompat's creature id extractor
-
 -- Uniform color helper
 function Utils.colorText(text, r, g, b)
        return Utils.WrapTextInColorCode(text, "ff" .. Utils.RGBPercToHex(r or 1, g or 0.82, b or 0))


### PR DESCRIPTION
## Summary
- handle boss deaths via LibCompat GUID helpers and boss lookups
- drop legacy Utils.getNpcId alias

## Testing
- `luac -p KRT.lua Modules/Utils.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c05bdec3f0832ea8b85d1703dd157f