### PR TITLE
Handle missing KRT global gracefully

### DIFF
--- a/!KRT/modules/bossList.lua
+++ b/!KRT/modules/bossList.lua
@@ -5,7 +5,10 @@ local KRT = _G["KRT"]
 if not KRT then
     -- This should ideally not happen if the .toc load order is correct,
     -- but it's a good defensive check.
-    error("KRT global table not found when loading bossList.lua")
+    if DEFAULT_CHAT_FRAME then
+        DEFAULT_CHAT_FRAME:AddMessage("KRT: KRT global table not found when loading bossList.lua")
+    end
+    return
 end
 
 -- List of bosses IDs to track:

--- a/!KRT/modules/ignoredItems.lua
+++ b/!KRT/modules/ignoredItems.lua
@@ -5,7 +5,10 @@ local KRT = _G["KRT"]
 if not KRT then
     -- This should ideally not happen if the .toc load order is correct,
     -- but it's a good defensive check.
-    error("KRT global table not found when loading ignoredItems.lua")
+    if DEFAULT_CHAT_FRAME then
+        DEFAULT_CHAT_FRAME:AddMessage("KRT: KRT global table not found when loading ignoredItems.lua")
+    end
+    return
 end
 
 -- Items to ignore when adding raids loot:


### PR DESCRIPTION
## Summary
- guard bossList and ignoredItems modules against missing KRT global
- notify users through DEFAULT_CHAT_FRAME when configuration is incorrect

## Testing
- `luac -p '!KRT/modules/bossList.lua' && echo 'bossList.lua syntax OK'`
- `luac -p '!KRT/modules/ignoredItems.lua' && echo 'ignoredItems.lua syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c06d5166bc832e80eebf707c27cdc9