### PR TITLE
fix(rolls): use uppercase roll type constants

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -2207,11 +2207,11 @@ do
         countdownRun = false
         local itemLink = GetItemLink()
         if itemLink == nil then return end
-        currentRollType = rollTypes.hold
+        currentRollType = rollTypes.HOLD
         if fromInventory == true then
-            return TradeItem(itemLink, holder, rollTypes.hold, 0)
+            return TradeItem(itemLink, holder, rollTypes.HOLD, 0)
         end
-        return AssignItem(itemLink, holder, rollTypes.hold, 0)
+        return AssignItem(itemLink, holder, rollTypes.HOLD, 0)
     end
 
     --
@@ -2222,11 +2222,11 @@ do
         countdownRun = false
         local itemLink = GetItemLink()
         if itemLink == nil then return end
-        currentRollType = rollTypes.bank
+        currentRollType = rollTypes.BANK
         if fromInventory == true then
-            return TradeItem(itemLink, banker, rollTypes.bank, 0)
+            return TradeItem(itemLink, banker, rollTypes.BANK, 0)
         end
-        return AssignItem(itemLink, banker, rollTypes.bank, 0)
+        return AssignItem(itemLink, banker, rollTypes.BANK, 0)
     end
 
     --
@@ -2237,11 +2237,11 @@ do
         countdownRun = false
         local itemLink = GetItemLink()
         if itemLink == nil then return end
-        currentRollType = rollTypes.disenchant
+        currentRollType = rollTypes.DISENCHANT
         if fromInventory == true then
-            return TradeItem(itemLink, disenchanter, rollTypes.disenchant, 0)
+            return TradeItem(itemLink, disenchanter, rollTypes.DISENCHANT, 0)
         end
-        return AssignItem(itemLink, disenchanter, rollTypes.disenchant, 0)
+        return AssignItem(itemLink, disenchanter, rollTypes.DISENCHANT, 0)
     end
 
     --
@@ -2681,17 +2681,17 @@ do
                 local output, whisper
                 if rollType <= 4 and addon.options.announceOnWin then
                     output = L.ChatAward:format(playerName, itemLink)
-                elseif rollType == rollTypes.hold and addon.options.announceOnHold then
+                elseif rollType == rollTypes.HOLD and addon.options.announceOnHold then
                     output = L.ChatHold:format(playerName, itemLink)
                     if addon.options.lootWhispers then
                         whisper = L.WhisperHoldAssign:format(itemLink)
                     end
-                elseif rollType == rollTypes.bank and addon.options.announceOnBank then
+                elseif rollType == rollTypes.BANK and addon.options.announceOnBank then
                     output = L.ChatBank:format(playerName, itemLink)
                     if addon.options.lootWhispers then
                         whisper = L.WhisperBankAssign:format(itemLink)
                     end
-                elseif rollType == rollTypes.disenchant and addon.options.announceOnDisenchant then
+                elseif rollType == rollTypes.DISENCHANT and addon.options.announceOnDisenchant then
                     output = L.ChatDisenchant:format(itemLink, playerName)
                     if addon.options.lootWhispers then
                         whisper = L.WhisperDisenchantAssign:format(itemLink)
@@ -2726,21 +2726,21 @@ do
         if rollType <= 4 and addon.options.announceOnWin then
             output = L.ChatAward:format(playerName, itemLink)
             keep = false
-        elseif rollType == rollTypes.hold and addon.options.announceOnHold then
+        elseif rollType == rollTypes.HOLD and addon.options.announceOnHold then
             output = L.ChatNoneRolledHold:format(itemLink, playerName)
-        elseif rollType == rollTypes.bank and addon.options.announceOnBank then
+        elseif rollType == rollTypes.BANK and addon.options.announceOnBank then
             output = L.ChatNoneRolledBank:format(itemLink, playerName)
-        elseif rollType == rollTypes.disenchant and addon.options.announceOnDisenchant then
+        elseif rollType == rollTypes.DISENCHANT and addon.options.announceOnDisenchant then
             output = L.ChatNoneRolledDisenchant:format(itemLink, playerName)
         end
 
         -- Keeping the item:
         if keep then
-            if rollType == rollTypes.hold then
+            if rollType == rollTypes.HOLD then
                 whisper = L.WhisperHoldTrade:format(itemLink)
-            elseif rollType == rollTypes.bank then
+            elseif rollType == rollTypes.BANK then
                 whisper = L.WhisperBankTrade:format(itemLink)
-            elseif rollType == rollTypes.disenchant then
+            elseif rollType == rollTypes.DISENCHANT then
                 whisper = L.WhisperDisenchantTrade:format(itemLink)
             end
             -- Multiple winners:
@@ -2802,7 +2802,7 @@ do
                     Utils.whisper(playerName, whisper)
                 end
             end
-            if rollType <= rollTypes.free and playerName == trader then
+            if rollType <= rollTypes.FREE and playerName == trader then
                 addon.History.Loot:Log(currentRollItem, trader, rollType, rollValue)
             end
             announced = true


### PR DESCRIPTION
## Summary
- replace roll type lookups with uppercase constants in `BtnHold`, `BtnBank`, and `BtnDisenchant`
- normalize roll-type comparisons in item award and trade logic

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c08aa71be4832ebf8942eb435a13e8