### PR TITLE
fix(loot): use timer aliases in LOOT_CLOSED

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -2612,10 +2612,10 @@ do
     function module:LOOT_CLOSED()
         if addon.Raid:IsMasterLooter() then
             if lootCloseTimer then
-                Utils.CancelTimer(lootCloseTimer)
+                CancelTimer(lootCloseTimer)
                 lootCloseTimer = nil
             end
-            lootCloseTimer = Utils.after(0.1, function()
+            lootCloseTimer = After(0.1, function()
                 lootCloseTimer = nil
                 lootOpened = false
                 UIMaster:Hide()


### PR DESCRIPTION
## Summary
- replace `Utils.CancelTimer` and `Utils.after` with localized timer aliases in `LOOT_CLOSED`
- audit repo for other `Utils` timer calls (none found)

## Testing
- `luac -p !KRT/KRT.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c08acf6bf8832e9acdac3755b5fe3b