### PR TITLE
fix(minimap): skip position update in free drag

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1317,9 +1317,14 @@ do
         end)
         KRT_MINIMAP_GUI:SetScript("OnMouseUp", function(self)
             self:SetScript("OnUpdate", nil)
+            if dragMode == "free" then
+                dragMode = nil
+                return
+            end
             local mx, my = Minimap:GetCenter()
             local bx, by = self:GetCenter()
             module:SetPos(deg(atan2(by - my, bx - mx)))
+            dragMode = nil
         end)
         KRT_MINIMAP_GUI:SetScript("OnClick", function(self, button, down)
             -- Ignore clicks if Shift or Alt keys are held:


### PR DESCRIPTION
## Summary
- avoid updating minimap button position when free-drag mode is active
- reset drag mode after releasing the button

## Testing
- `luacheck !KRT/KRT.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c08adc87ac832ebcd408620786e7c9