### PR TITLE
fix(rolls): localize rolled state variable

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1381,7 +1381,7 @@ do
     -------------------------------------------------------
     -- Internal state
     -------------------------------------------------------
-    local record, canRoll, warned = false, true, false
+    local record, canRoll, warned, rolled = false, true, false, false
     local playerRollTracker, rollsTable, rerolled, itemRollTracker = {}, {}, {}, {}
     local selectedPlayer = nil
 


### PR DESCRIPTION
## Summary
- declare `rolled` flag in `addon.Rolls` internal state alongside `record`, `canRoll`, and `warned`

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c0af11ee38832eb945c05326b317cf