### PR TITLE
fix(rolls): use roster class data

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1718,7 +1718,7 @@ do
             local nameStr, rollStr, star = _G[btnName .. "Name"], _G[btnName .. "Roll"], _G[btnName .. "Star"]
 
             if nameStr and nameStr.SetVertexColor then
-                local _, class = UnitClass(name)
+                local class = addon.Raid:GetPlayerClass(name)
                 class = class and class:upper() or "UNKNOWN"
                 if isSR and self:IsReserved(itemId, name) then
                     nameStr:SetVertexColor(0.4, 0.6, 1.0)


### PR DESCRIPTION
## Summary
- use addon.Raid:GetPlayerClass when building roll list
- default to UNKNOWN when class data is missing

## Testing
- `luac -p '!KRT/KRT.lua'`

------
https://chatgpt.com/codex/tasks/task_e_68c0af15a384832e9301a4b7a4299345