### PR TITLE
fix(rolls): guard HighestRoll when no winner

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1574,6 +1574,7 @@ do
     -- Returns the highest roll value from the current winner.
     --
     function module:HighestRoll()
+        if not winner or rollsCount == 0 then return 0 end
         for i = 1, rollsCount do
             if rollsTable[i].name == winner then
                 addon:Debug("DEBUG", "HighestRoll: %s rolled %d", winner, rollsTable[i].roll)


### PR DESCRIPTION
## Summary
- avoid iterating for HighestRoll if there's no winner or rolls

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68c0aff53210832e9dbb52d01aa02854