### PR TITLE
fix(rolls): guard ClearRolls UI cleanup

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1587,22 +1587,23 @@ do
     -- Clears all roll-related state and UI elements.
     --
     function module:ClearRolls(rec)
-        frameName = frameName or Utils.getFrameName()
-        if not frameName then return end
+        local frameName = Utils.getFrameName()
         rollsTable, rerolled, itemRollTracker = {}, {}, {}
         playerRollTracker, rolled, warned, rollsCount = {}, false, false, 0
         selectedPlayer = nil
         if rec == false then record = false end
 
-        local i = 1
-        local btn = _G[frameName .. "PlayerBtn" .. i]
-        while btn do
-            btn:Hide()
-            i = i + 1
-            btn = _G[frameName .. "PlayerBtn" .. i]
-        end
+        if frameName then
+            local i = 1
+            local btn = _G[frameName .. "PlayerBtn" .. i]
+            while btn do
+                btn:Hide()
+                i = i + 1
+                btn = _G[frameName .. "PlayerBtn" .. i]
+            end
 
-        addon.Raid:ClearRaidIcons()
+            addon.Raid:ClearRaidIcons()
+        end
     end
 
     --


### PR DESCRIPTION
## Summary
- Resolve `frameName` locally in `ClearRolls`
- Skip UI cleanup if no roll frame is available

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c0affb22a0832e993c91c1fb7bd412