### PR TITLE
fix(ui): refresh master dropdowns on roster changes

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -358,6 +358,9 @@ do
         if not IsInGroup() then
             numRaid = 0
             module:End()
+            if addon.Master and addon.Master.PrepareDropDowns then
+                addon.Master:PrepareDropDowns()
+            end
             return
         end
 
@@ -428,6 +431,9 @@ do
                 v.leave = Utils.getCurrentTime()
             end
             v.seen = nil
+        end
+        if addon.Master and addon.Master.PrepareDropDowns then
+            addon.Master:PrepareDropDowns()
         end
     end
 
@@ -2446,6 +2452,7 @@ do
             end
         end
     end
+    module.PrepareDropDowns = PrepareDropDowns
 
     --
     -- OnClick handler for dropdown menu items.


### PR DESCRIPTION
## Summary
- refresh master dropdown menus when raid roster updates or group changes
- expose `PrepareDropDowns` for reuse

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c0afe9fb08832eac9d34902f321df5