### PR TITLE
fix(rolls): handle missing top roll winner

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1397,8 +1397,13 @@ do
                 end
                 return a.roll > b.roll
             end)
-            winner = rollsTable[1].name
-            addon:Debug("DEBUG", "Sorted rolls; current winner: %s with roll: %d", winner, rollsTable[1].roll)
+            if rollsTable[1] then
+                winner = rollsTable[1].name
+                addon:Debug("DEBUG", "Sorted rolls; current winner: %s with roll: %d", winner, rollsTable[1].roll)
+            else
+                winner = nil
+                addon:Debug("DEBUG", "Sorted rolls; no winner")
+            end
         end
     end
 
@@ -1574,6 +1579,10 @@ do
     -- Returns the highest roll value from the current winner.
     --
     function module:HighestRoll()
+        if not winner then
+            addon:Debug("DEBUG", "HighestRoll: no winner")
+            return 0
+        end
         for i = 1, rollsCount do
             if rollsTable[i].name == winner then
                 addon:Debug("DEBUG", "HighestRoll: %s rolled %d", winner, rollsTable[i].roll)


### PR DESCRIPTION
## Summary
- guard winner assignment if roll list is empty
- return 0 from `HighestRoll` when winner is nil

## Testing
- `luacheck '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c0affe0b48832eb7b59bd1b2f8b4da