### PR TITLE
fix(rolls): default SR highlight to winner

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1690,6 +1690,9 @@ do
                         starTarget = name
                     end
                 end
+                if isSR and not starTarget then
+                    starTarget = winner
+                end
                 addon:Debug("DEBUG", "Top SR roll by: %s", tostring(starTarget))
             else
                 starTarget = winner


### PR DESCRIPTION
## Summary
- when no SR reserve is found, highlight the roll winner instead

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c0b0072fec832e948133b353f1b5a2