### PR TITLE
fix(rolls): guard winner when no rolls exist

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1433,8 +1433,13 @@ do
                 end
                 return a.roll > b.roll
             end)
-            winner = rollsTable[1].name
-            addon:Debug("DEBUG", "Sorted rolls; current winner: %s with roll: %d", winner, rollsTable[1].roll)
+            if rollsTable[1] then
+                winner = rollsTable[1].name
+                addon:Debug("DEBUG", "Sorted rolls; current winner: %s with roll: %d", winner, rollsTable[1].roll)
+            else
+                winner = nil
+                addon:Debug("DEBUG", "Sorted rolls; no winner")
+            end
         end
     end
 
@@ -1610,7 +1615,10 @@ do
     -- Returns the highest roll value from the current winner.
     --
     function module:HighestRoll()
-        if not winner or rollsCount == 0 then return 0 end
+        if not winner then
+            addon:Debug("DEBUG", "HighestRoll: winner is nil")
+            return 0
+        end
         for i = 1, rollsCount do
             if rollsTable[i].name == winner then
                 addon:Debug("DEBUG", "HighestRoll: %s rolled %d", winner, rollsTable[i].roll)
@@ -2831,7 +2839,7 @@ do
                 -- Player is out of range
                 addon.Raid:ClearRaidIcons()
                 SetRaidTarget(trader, 1)
-                SetRaidTarget(winner, 4)
+                if winner then SetRaidTarget(winner, 4) end
                 output = L.ChatTrade:format(playerName, itemLink)
             end
         end


### PR DESCRIPTION
## Summary
- avoid assigning a winner when no rolls exist
- log missing winner in `HighestRoll`
- skip setting raid target when winner absent

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68c127194404832e8e8fc77c697b1a27