### PR TITLE
fix(loot): parse 'You won' item correctly

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -667,11 +667,8 @@ do
         -- Other Loot Rolls
         if not player or not itemLink then
             itemCount = 1
-            player, itemLink = addon.Deformat(msg, LOOT_ROLL_YOU_WON)
-            if not itemLink then
-                player = unitName
-                itemLink = addon.Deformat(msg, LOOT_ROLL_YOU_WON)
-            end
+            itemLink = addon.Deformat(msg, LOOT_ROLL_YOU_WON)
+            player = unitName
         end
         if not itemLink then return end
         local _, _, itemString = string.find(itemLink, "^|c%x+|H(.+)|h%[.*%]")


### PR DESCRIPTION
## Summary
- Simplify Raid:AddLoot parsing for `LOOT_ROLL_YOU_WON` messages so item is captured and player defaults to `unitName`

## Testing
- `luac -p \!KRT/KRT.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c12b4dcba0832eabe13d1246c421fd