### PR TITLE
fix(minimap): correct circular drag positioning

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -1309,14 +1309,12 @@ do
             self:ClearAllPoints()
             self:SetPoint("CENTER", x, y)
         else
-            -- Circular drag mode
-            centerX, centerY = abs(x), abs(y)
-            centerX = (centerX / sqrt(centerX ^ 2 + centerY ^ 2)) * 80
-            centerY = (centerY / sqrt(centerX ^ 2 + centerY ^ 2)) * 80
-            centerX = x < 0 and -centerX or centerX
-            centerY = y < 0 and -centerY or centerY
+            -- Circular drag mode (snap to ring radius ~80)
+            local dist = sqrt(x * x + y * y)
+            if dist == 0 then dist = 1 end
+            local px, py = (x / dist) * 80, (y / dist) * 80
             self:ClearAllPoints()
-            self:SetPoint("CENTER", centerX, centerY)
+            self:SetPoint("CENTER", px, py)
         end
     end
 


### PR DESCRIPTION
## Summary
- fix minimap circular drag math by using normalized cursor vectors

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c12bdc13e8832ea6371d6b861407dd