### PR TITLE
fix(raid): add GetRaidDifficultyID fallback

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -781,12 +781,10 @@ do
     -- Returns raid size: 10 or 25.
     --
     function module:GetRaidSize()
-        local size = 0
-        if IsInRaid() then
-            local diff = GetRaidDifficulty()
-            size = (diff == 1 or diff == 3) and 10 or 25
-        end
-        return size
+        if not IsInRaid() then return 0 end
+        local diff = GetRaidDifficulty and GetRaidDifficulty() or (GetRaidDifficultyID and GetRaidDifficultyID())
+        if not diff then return (GetNumGroupMembers() > 10) and 25 or 10 end
+        return (diff == 1 or diff == 3) and 10 or 25
     end
 
     --


### PR DESCRIPTION
## Summary
- fallback to `GetRaidDifficultyID` when `GetRaidDifficulty` is unavailable

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c12c104fb4832e932086fe6b576d96