### PR TITLE
perf(libs): cache library lookups

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -35,18 +35,18 @@ KRT_PlayerCounts        = KRT_PlayerCounts or {}
 ---============================================================================
 -- External Libraries / Bootstrap
 ---============================================================================
-local LibStub           = _G.LibStub
-if LibStub then
-    addon.Compat          = LibStub("LibCompat-1.0")
-    addon.BossIDs         = LibStub("LibBossIDs-1.0", true)
-    addon.Logger          = LibStub("LibLogger-1.0", true)
-    addon.Deformat        = LibStub("LibDeformat-3.0", true)
-    addon.CallbackHandler = LibStub("CallbackHandler-1.0", true)
+local Compat            = addon:GetLib("LibCompat-1.0")
+addon.Compat            = Compat
+addon.BossIDs           = addon:GetLib("LibBossIDs-1.0", true)
+addon.Logger            = addon:GetLib("LibLogger-1.0", true)
+addon.Deformat          = addon:GetLib("LibDeformat-3.0", true)
+addon.CallbackHandler   = addon:GetLib("CallbackHandler-1.0", true)
 
-    addon.Compat:Embed(addon) -- mixin: After, UnitIterator, GetCreatureId, etc.
-    if addon.Logger and addon.Logger.Embed then
-        addon.Logger:Embed(addon)
-    end
+if Compat and Compat.Embed then
+    Compat:Embed(addon) -- mixin: After, UnitIterator, GetCreatureId, etc.
+end
+if addon.Logger and addon.Logger.Embed then
+    addon.Logger:Embed(addon)
 end
 
 do

--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -4,7 +4,19 @@ addon.Utils            = addon.Utils or {}
 local Utils            = addon.Utils
 local L                = addon.L
 local LibStub          = _G.LibStub
-local Compat           = addon.Compat or (LibStub and LibStub("LibCompat-1.0", true))
+
+-- Library helper: caches LibStub lookups
+function addon:GetLib(name, silent)
+        self.libs = self.libs or {}
+        local lib = self.libs[name]
+        if not lib and LibStub then
+                lib = LibStub(name, silent)
+                self.libs[name] = lib
+        end
+        return lib
+end
+
+local Compat = addon:GetLib("LibCompat-1.0", true)
 if Compat then
         addon.Compat = Compat
         Compat:Embed(Utils)


### PR DESCRIPTION
## Summary
- add addon:GetLib helper to cache LibStub library lookups
- use cached lookup to embed required libraries once

## Testing
- `luac -p '!KRT/Modules/Utils.lua'`
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c13db72084832e9d63e0f42b2ae675