### PR TITLE
ref(constants): remove unused DKP reference

### DIFF
--- a/!KRT/Localization/localization.en.lua
+++ b/!KRT/Localization/localization.en.lua
@@ -215,9 +215,9 @@ L.StrConfirmDeleteItem            = "Are you sure you want to delete this item f
 L.StrEditItemLooter               = "Change winner"
 L.StrEditItemLooterHelp           = "Enter the name of the winner:"
 L.StrEditItemRollType             = "Change roll type"
-L.StrEditItemRollTypeHelp         = "1=MS, 2=OS, 3=Free, 4=Bank, 5=DE, 6=Hold, 7=DKP"
+L.StrEditItemRollTypeHelp         = "1=MS, 2=OS, 3=Free, 4=Bank, 5=DE, 6=Hold"
 L.StrEditItemRollValue            = "Change roll value"
-L.StrEditItemRollValueHelp        = "Enter the value of the roll or DKP:"
+L.StrEditItemRollValueHelp        = "Enter the value of the roll:"
 
 -- Add/Edit Boss:
 L.StrAddBoss                      = "Add Boss"

--- a/!KRT/Modules/C.lua
+++ b/!KRT/Modules/C.lua
@@ -17,7 +17,6 @@ C.rollTypes = {
     BANK       = 5,
     DISENCHANT = 6,
     HOLD       = 7,
-    DKP        = 8,
 }
 
 -- Roll Type Display Text
@@ -40,7 +39,6 @@ C.lootTypesColored = {
     "|cffff7f00" .. L.BtnBank .. "|r",
     "|cffff2020" .. L.BtnDisenchant .. "|r",
     "|cffffffff" .. L.BtnHold .. "|r",
-    "|cff20ff20DKP|r",
 }
 
 -- Item Quality Colors


### PR DESCRIPTION
## Summary
- remove DKP from roll type constants
- update localization strings to drop DKP references

## Testing
- `luacheck '!KRT/Modules/C.lua' '!KRT/Localization/localization.en.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c159dbb738832eb3dc203dcfaed2a1