### PR TITLE
ref(utils): centralize compat helpers

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -50,6 +50,16 @@ addon.CallbackHandler   = addon:GetLib("CallbackHandler-1.0", true)
 
 if Compat and Compat.Embed then
     Compat:Embed(addon) -- mixin: After, UnitIterator, GetCreatureId, etc.
+    if addon.Utils then
+        addon.Utils.After       = addon.After
+        addon.Utils.NewTicker   = addon.NewTicker
+        addon.Utils.CancelTimer = addon.CancelTimer
+        addon.Utils.UnitIterator = addon.UnitIterator
+        addon.Utils.tCopy       = addon.tCopy
+        addon.Utils.tLength     = addon.tLength
+        addon.Utils.tContains   = addon.tContains
+        addon.Utils.tIndexOf    = addon.tIndexOf
+    end
 end
 if addon.Logger and addon.Logger.Embed then
     addon.Logger:Embed(addon)

--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -16,16 +16,6 @@ function addon:GetLib(name, silent)
         return lib
 end
 
-local Compat = addon:GetLib("LibCompat-1.0", true)
-if Compat then
-        addon.Compat = Compat
-        Compat:Embed(Utils)
-        Utils.tCopy     = Compat.tCopy
-        Utils.tLength   = Compat.tLength
-        Utils.tContains = Compat.tContains
-        Utils.tIndexOf  = Compat.tIndexOf
-end
-
 -- Practical helper aliases
 function Utils.after(sec, fn) return Utils.After(sec, fn) end
 
@@ -150,12 +140,12 @@ function Utils.rgbToHex(r, g, b)
 	if r and g and b and r <= 1 and g <= 1 and b <= 1 then
 		r, g, b = r * 255, g * 255, b * 255
 	end
-	return Compat.RGBToHex(r, g, b)
+        return addon.Compat.RGBToHex(r, g, b)
 end
 
 function addon.GetClassColor(name)
 	name = (name == "DEATH KNIGHT") and "DEATHKNIGHT" or name
-	local c = Compat.GetClassColorObj(name)
+        local c = addon.Compat.GetClassColorObj(name)
 	if not c then
 		return 1, 1, 1
 	end
@@ -210,7 +200,7 @@ function Utils.showHide(frame, cond)
 end
 
 function Utils.createPool(frameType, parent, template, resetter)
-	return Compat.CreateFramePool(frameType, parent, template, resetter)
+        return addon.Compat.CreateFramePool(frameType, parent, template, resetter)
 end
 
 -- Lock/Unlock Highlight:


### PR DESCRIPTION
## Summary
- Mirror LibCompat timer and table helpers from the core addon onto `addon.Utils`
- Drop separate LibCompat lookup in Utils and use core `addon.Compat` for color and frame helpers

## Testing
- `luac -p '!KRT/KRT.lua'`
- `luac -p '!KRT/Modules/Utils.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c1686f1024832e96d7c0f434392c13