### PR TITLE
perf(utils): cache failed lib lookups

### DIFF
--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -8,11 +8,12 @@ local LibStub          = _G.LibStub
 -- Library helper: caches LibStub lookups
 function addon:GetLib(name, silent)
         self.libs = self.libs or {}
-        local lib = self.libs[name]
-        if not lib and LibStub then
-                lib = LibStub(name, silent)
-                self.libs[name] = lib
+        local cached = self.libs[name]
+        if cached ~= nil then
+                return cached or nil
         end
+        local lib = LibStub and LibStub(name, silent)
+        self.libs[name] = lib or false
         return lib
 end
 


### PR DESCRIPTION
## Summary
- cache failed LibStub lookups via false sentinel to avoid repeated calls

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68c171ea7ac4832e9755f063de71fa03