### PR TITLE
refactor: remove redundant LibStub nil check

### DIFF
--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -12,7 +12,7 @@ function addon:GetLib(name, silent)
         if cached ~= nil then
                 return cached or nil
         end
-        local lib = LibStub and LibStub(name, silent)
+        local lib = LibStub(name, silent)
         self.libs[name] = lib or false
         return lib
 end


### PR DESCRIPTION
## Summary
- call LibStub directly when retrieving libraries to simplify GetLib

## Testing
- `luacheck '!KRT/Modules/Utils.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c5f1c48658832eb39aa360a57f204b