### PR TITLE
refactor: define GetItemIndex before use

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -167,10 +167,15 @@ local lootCount                         = 0
 local rollsCount                        = 0
 local itemCount                         = 1
 local itemTraded                        = 0
+local currentItemIndex                  = 0
 
 -- Function placeholders for loot helpers
 local ItemExists, ItemIsSoulbound, GetItem
 local GetItemIndex, GetItemName, GetItemLink, GetItemTexture
+
+function GetItemIndex()
+    return currentItemIndex
+end
 
 ---============================================================================
 -- Cached Functions & Libraries
@@ -1520,7 +1525,7 @@ do
 
     -- Gets the item ID of the item currently being rolled for.
     function module:GetCurrentRollItemID()
-        local index = GetItemIndex and GetItemIndex() or 1
+        local index = GetItemIndex()
         local item = GetItem and GetItem(index)
         local itemLink = item and item.itemLink
         if not itemLink then return nil end
@@ -1663,7 +1668,6 @@ do
     -- Internal state
     -------------------------------------------------------
     local lootTable = {}
-    local currentItemIndex = 0
 
     -------------------------------------------------------
     -- Private helpers
@@ -1794,14 +1798,6 @@ do
         end
     end
 
-    --
-    -- Returns the index of the currently selected item.
-    --
-    function GetItemIndex()
-        return currentItemIndex
-    end
-
-    --
     -- Returns the table for the currently selected item.
     --
     function GetItem(i)


### PR DESCRIPTION
## Summary
- ensure GetItemIndex is always available before GetCurrentRollItemID
- simplify GetCurrentRollItemID by calling GetItemIndex directly

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c5f1bd937c832e8cfe12ee3c3dbc48