### PR TITLE
refactor: embed libs and expose utils

### DIFF
--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -48,22 +48,16 @@ addon.Logger            = addon:GetLib("LibLogger-1.0", true)
 addon.Deformat          = addon:GetLib("LibDeformat-3.0", true)
 addon.CallbackHandler   = addon:GetLib("CallbackHandler-1.0", true)
 
-if Compat and Compat.Embed then
-    Compat:Embed(addon) -- mixin: After, UnitIterator, GetCreatureId, etc.
-    if addon.Utils then
-        addon.Utils.After       = addon.After
-        addon.Utils.NewTicker   = addon.NewTicker
-        addon.Utils.CancelTimer = addon.CancelTimer
-        addon.Utils.UnitIterator = addon.UnitIterator
-        addon.Utils.tCopy       = addon.tCopy
-        addon.Utils.tLength     = addon.tLength
-        addon.Utils.tContains   = addon.tContains
-        addon.Utils.tIndexOf    = addon.tIndexOf
-    end
-end
-if addon.Logger and addon.Logger.Embed then
-    addon.Logger:Embed(addon)
-end
+Compat:Embed(addon) -- mixin: After, UnitIterator, GetCreatureId, etc.
+addon.Logger:Embed(addon)
+addon.Utils.After        = addon.After
+addon.Utils.NewTicker    = addon.NewTicker
+addon.Utils.CancelTimer  = addon.CancelTimer
+addon.Utils.UnitIterator = addon.UnitIterator
+addon.Utils.tCopy        = addon.tCopy
+addon.Utils.tLength      = addon.tLength
+addon.Utils.tContains    = addon.tContains
+addon.Utils.tIndexOf     = addon.tIndexOf
 
 -- Alias locali (safe e veloci)
 local IsInRaid             = addon.IsInRaid


### PR DESCRIPTION
## Summary
- always embed Compat and Logger libraries
- expose timer and table helpers on addon.Utils without guard

## Testing
- `luac -p '!KRT/KRT.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c5f1812764832ea7ce18a5ba4cf86d