### PR TITLE
chore: unify descriptions to English

### DIFF
--- a/!KRT/!KRT.toc
+++ b/!KRT/!KRT.toc
@@ -1,7 +1,6 @@
 ## Interface: 30300
 ## Title: !|cfff58cbaK|r|caaf49141RaidTools|r
 ## Notes: |cfff58cbaKader|r|caaf49141RaidTools|r makes the raid leader's life easier.
-## Notes-frFR: |cff69ccf0Kader|r|caaf49141RaidTools|r facilite la vie du chef de raid.
 ## Author: Kader (|cff808080bkader#5341|r)
 ## DefaultState: enabled
 ## SavedVariables: KRT_Options, KRT_Raids, KRT_Players, KRT_Warnings, KRT_ExportString, KRT_Spammer, KRT_CurrentRaid, KRT_LastBoss, KRT_NextReset, KRT_SavedReserves, KRT_PlayerCounts, KRT_Debug
@@ -12,7 +11,7 @@
 ## X-Email: bkader@mail.com
 ## X-Website: https://github.com/bkader/KRT
 ## X-Discord: https://discord.gg/a8z5CyS3eW
-## X-Localizations: Kader (frFR)
+## X-Localizations: Kader (enUS)
 
 # Libraries:
 Libs\libs.xml

--- a/!KRT/KRT.lua
+++ b/!KRT/KRT.lua
@@ -4698,7 +4698,7 @@ local function selectAndTrigger(ns, field, id, event)
     return ns[field]
 end
 
--- popup di conferma compatto
+-- compact confirmation popup
 local function makeConfirmPopup(key, text, onAccept, cancels)
     StaticPopupDialogs[key] = {
         text         = text,
@@ -4712,7 +4712,7 @@ local function makeConfirmPopup(key, text, onAccept, cancels)
     }
 end
 
--- cache dei child più usati per ridurre _G[...] ripetuti
+-- cache frequently used children to reduce repeated _G[...] lookups
 local function CacheParts(row, name, parts)
     if row._p then return row._p end
     local p = {}
@@ -5413,11 +5413,11 @@ do
             _G[n .. "Title"]:SetText(L.StrRaidAttendees)
             _G[n .. "HeaderJoin"]:SetText(L.StrJoin)
             _G[n .. "HeaderLeave"]:SetText(L.StrLeave)
-            -- FIXME: riattivare quando implementato
+            -- FIXME: re-enable when implemented
             _G[n .. "AddBtn"]:Disable(); _G[n .. "DeleteBtn"]:Disable()
         end,
 
-        -- Preformat join/leave per la UI
+        -- Preformat join/leave for the UI
         getData        = function(out)
             local src = addon.Raid:GetPlayers(addon.History.selectedRaid) or {}
             for i = 1, #src do
@@ -5527,12 +5527,12 @@ do
             _G[n .. "HeaderType"]:SetText(L.StrType)
             _G[n .. "HeaderRoll"]:SetText(L.StrRoll)
             _G[n .. "HeaderTime"]:SetText(L.StrTime)
-            -- FIXME: disabilitati finché non implementati
+            -- FIXME: disabled until implemented
             _G[n .. "ExportBtn"]:Disable(); _G[n .. "ClearBtn"]:Disable(); _G[n .. "AddBtn"]:Disable(); _G
                 [n .. "EditBtn"]:Disable()
         end,
 
-        -- Preformat time per la UI (mantieni i campi numerici per sort/logica)
+        -- Preformat time for the UI (keep numeric fields for sorting/logic)
         getData        = function(out)
             raidLoot = addon.Raid:GetLoot(addon.History.selectedRaid) or {}
 

--- a/!KRT/Localization/localization.en.lua
+++ b/!KRT/Localization/localization.en.lua
@@ -306,11 +306,11 @@ L.RaidZones                       = {
 	["The Eye of Eternity"] = "The Eye of Eternity",
 	["Vault of Archavon"] = "Vault of Archavon",
 	["Ulduar"] = "Ulduar",
-	["Onyxia's Lair"] = "Onyxia's Lair",                          -- Nota: Onyxia è presente anche in Classic
+        ["Onyxia's Lair"] = "Onyxia's Lair",                          -- Note: Onyxia is also present in Classic
 	["Trial of the Crusader"] = "Trial of the Crusader",
-	["Trial of the Grand Crusader"] = "Trial of the Grand Crusader", -- Già presente, lo mantengo
+        ["Trial of the Grand Crusader"] = "Trial of the Grand Crusader", -- Already present, keeping it
 	["Icecrown Citadel"] = "Icecrown Citadel",
-	["The Ruby Sanctum"] = "The Ruby Sanctum",                    -- Già presente, lo mantengo
+        ["The Ruby Sanctum"] = "The Ruby Sanctum",                    -- Already present, keeping it
 }
 -- The reason we are using these is because of the missing
 -- UNIT_DIED event once these bosses are dealt with.


### PR DESCRIPTION
## Summary
- remove French notes metadata and point localization to enUS
- translate remaining Italian comments to English in core files

## Testing
- `luac -p '!KRT/KRT.lua'`
- `luac -p '!KRT/Localization/localization.en.lua'`


------
https://chatgpt.com/codex/tasks/task_e_68c60f8d9a80832eb203d6237918d309