### PR TITLE
Remove caching for library lookups

### DIFF
--- a/!KRT/Modules/Utils.lua
+++ b/!KRT/Modules/Utils.lua
@@ -4,17 +4,10 @@ addon.Utils            = addon.Utils or {}
 local Utils            = addon.Utils
 local L                = addon.L
 
--- Library helper: caches LibStub lookups
+-- Library helper: direct LibStub lookup
 function addon:GetLib(name, silent)
-        self.libs = self.libs or {}
-        local cached = self.libs[name]
-        if cached ~= nil then
-                return cached or nil
-        end
-        local LibStub = _G.LibStub
-        local lib = LibStub(name, silent)
-        self.libs[name] = lib or false
-        return lib
+	local LibStub = _G.LibStub
+	return LibStub(name, silent)
 end
 
 -- Practical helper aliases


### PR DESCRIPTION
## Summary
- update `addon:GetLib` to call LibStub directly instead of caching lookup results

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c86988d80c832e827a2f353ae19749